### PR TITLE
Fixed the CSV export from Drupal; Update link for Alice Black Blood Tribute

### DIFF
--- a/fate-product-list.csv
+++ b/fate-product-list.csv
@@ -287,7 +287,7 @@ Seven Spirits: A Fate Supplement,A.C. Luke,https://ac-luke.itch.io/fate-seven-sp
 Aces in Space,Vogt & Vriends,https://www.drivethrurpg.com/product/317497/Aces-In-Space?affiliate_id=144937
 Van Wizards vs The Mageocracy,SicklyGeek,https://jynjynx.itch.io/van-wizards
 El libro de Hanz: la guía para jugar Fate (Book of Hanz fan translation),La esquina del rol,https://laesquinadelrol.com/2021/07/29/librodehanz-epub/
-Alice Black Blood Tribute,Chris Challice,https://www.lulu.com/shop/chris-challice/alice-black-blood-tribute/ebook/product-1q2676jz.html?page=1&pageSize=4
+Alice Black Blood Tribute,Chris Challice,https://www.lulu.com/shop/chris-challice/alice-black-blood-tribute/ebook/product-1q2676jz.html
 Traditional Magic for Fate,ambergwitz,https://ambergwitz.itch.io/traditional-magic-for-fate
 Fate Fantastic Creatures,Rolepress,https://www.drivethrurpg.com/product/359590/Fate-Fantastic-Creatures?affiliate_id=144937
 Fate Plus Cyberpunk,Rolepress,https://www.drivethrurpg.com/product/387323/Fate-Plus-Cyberpunk?affiliate_id=144937

--- a/fate-product-list.csv
+++ b/fate-product-list.csv
@@ -1,302 +1,302 @@
-Timestamp,Product title,Publisher Name,Link to the product
-6/21/2024,Heartbreaker,A.C. Luke,https://ac-luke.itch.io/heartbreaker-trifold
-6/21/2024,Seven Demons: A Collection of NPCs for Fate Core,A.C. Luke,https://ac-luke.itch.io/fate-seven-demons
-6/21/2024,Seven Hunters: A Collection of NPCs for Fate Core,A.C. Luke,https://ac-luke.itch.io/fate-seven-hunters
-6/21/2024,Seven Spirits: A Fate Supplement,A.C. Luke,https://ac-luke.itch.io/fate-seven-spirits
-6/21/2024,According To Plan,Alex Costello,https://www.drivethrurpg.com/product/302251/According-To-Plan?affiliate_id=1449…
-6/21/2024,The Book of Hanz,Amazing Rando Design,https://fate-srd.com/store
-6/21/2024,Thoughts on Fate: A Collection of Essays on the Fate RPG,Amazing Rando Design,http://www.drivethrurpg.com/product/176051/Thoughts-on-Fate-A-Collection-of-Ess…
-6/21/2024,Traditional Magic for Fate,ambergwitz,https://ambergwitz.itch.io/traditional-magic-for-fate
-6/21/2024,The Kerberos Club (Fate Edition),Arc Dream Publishing,http://www.drivethrurpg.com/product/93899/The-Kerberos-Club-Fate-Edition?affili…
-6/21/2024,The Day After Ragnarok: Fate Core Edition,Atomic Overmind Press,https://www.drivethrurpg.com/product/119680/The-Day-After-Ragnarok-Fate-Core-Ed…
-6/21/2024,The Stuffed Guardians,Benjamin Z. Edelen,https://www.drivethrurpg.com/product/288784/The-Stuffed-Guardians?affiliate_id=…
-6/21/2024,Leaves of Chiaroscuro: Exploration & Intrigue in the Strange & Wondrous Renaissance,Bennett-Burks Design,http://drivethrurpg.com/product/190834/Leaves-of-Chiaroscuro-Exploration--Intri…
-6/21/2024,Thrilling Action Stories! for FATE,Black Campbell Entertainment,http://www.drivethrurpg.com/product/218484/Thrilling-Action-Stories-for-FATE-BU…
-6/21/2024,Dawning Star: Fate of Eos,Blue Devil Games,https://www.drivethrurpg.com/product/229377/Dawning-Star-Fate-of-Eos?affiliate_…
-6/21/2024,Grim World,Boldly Games,https://boldlygames.com/
-6/21/2024,Fate Solo,Cabbage Games,https://www.drivethrurpg.com/product/204162/Fate-Solo?affiliate_id=144937
-6/21/2024,Henchmen,Canterbury Games Studio,https://www.drivethrurpg.com/product/243740/Henchmen?affiliate_id=144937
-6/21/2024,Alice Black Blood Tribute,Chris Challice,https://www.lulu.com/shop/chris-challice/alice-black-blood-tribute/ebook/produc…
-6/21/2024,Ehdrigohr: The Roleplaying Game,Council Of Fools Productions,http://drivethrurpg.com/product/117380/Ehdrigohr-The-Roleplaying-Game?affiliate…
-6/21/2024,Hunters of Alexandria,D101 Games,http://www.drivethrurpg.com/product/159508/Hunters-of-Alexandria?affiliate_id=1…
-6/21/2024,The Hollow West,D101 Games,http://www.drivethrurpg.com/product/222039/The-Hollow-West?affiliate_id=144937
-6/21/2024,Berin Kinsman's Kaiju Patrol,Dancing Lights Press,http://rpg.drivethrustuff.com/product/139656/Berin-Kinsmans-Kaiju-Patrol?affili…
-6/21/2024,Daring Comics Role-Playing Game,Daring Entertainment,http://www.drivethrurpg.com/product/173130/Daring-Comics-RolePlaying-Game?affil…
-6/21/2024,Fatecharactersheet.com,Darktier Studios LLC,https://fatecharactersheet.com/
-6/21/2024,Demon Hunters: A Comedy of Terrors,Dead Gentlemen Productions LLC,http://drivethrurpg.com/product/169515/Demon-Hunters-A-Comedy-of-Terrors?affili…
-6/21/2024,Amethyst: Accelerated,Dias Ex Machina,http://www.drivethrurpg.com/product/157056/Amethyst--Accelerated-Fate-Edition?a…
-6/21/2024,Amethyst: Destiny (Fate Edition),Dias Ex Machina,http://rpg.drivethrustuff.com/product/134037/Amethyst-Destiny-Fate-Edition?affi…
-6/21/2024,Dreamcraft FATE Bot (Beta),Dreamcraft,https://discord.com/api/oauth2/authorize?client_id=704882221789478930&permissio…
-6/21/2024,Evolution Pulse - English Edition,Dreamlord Press,http://drivethrurpg.com/product/185979/Evolution-Pulse--English-Edition?affilia…
-6/21/2024,Aperita Arcana: Fantasy for Fate Core,Ebon Gryphon Games,http://drivethrurpg.com/product/149698/Aperita-Arcana-fantasy-for-Fate-Core?aff…
-6/21/2024,Collectanea Creaturae - Fate Core,Ebon Gryphon Games,http://www.drivethrurpg.com/product/130724/Collectanea-Creaturae--Fate-Core?aff…
-6/21/2024,Fate Acelerado,Ediciones conBarba,http://rpg.drivethrustuff.com/product/134320/Fate-Acelerado?affiliate_id=144937
-6/21/2024,Fate Core Character Journal,EldritchFire Press,http://rpg.drivethrustuff.com/product/118798/Fate-Core-Character-Journal?affili…
-6/21/2024,Five Elements: A Fate Core Magic System,EldritchFire Press,https://www.drivethrurpg.com/product/132834/Five-Elements-A-Fate-Core-Magic-Sys…
-6/21/2024,Iron Edda Accelerated,Encoded Designs,https://www.drivethrurpg.com/product/261741/Iron-Edda-Accelerated?affiliate_id=…
-6/21/2024,Aether Sea • A World of Adventure for Fate Core,Evil Hat Productions,http://rpg.drivethrustuff.com/product/139872/Aether-Sea--A-World-of-Adventure-f…
-6/21/2024,Almbrecht After Dark • A World of Adventure for Fate Core,Evil Hat Productions,https://www.drivethrurpg.com/product/263582/Almbrecht-After-Dark?affiliate_id=1…
-6/21/2024,Andromeda • A World of Adventure for Fate Core,Evil Hat Productions,https://www.drivethrurpg.com/product/202271/Andromeda--A-World-of-Adventure-for…
-6/21/2024,Arecibo • A World of Adventure for Fate Core,Evil Hat Productions,http://drivethrurpg.com/product/240445/Arecibo-o-A-World-of-Adventure-for-Fate-…
-6/21/2024,Arecibo • Foundry VTT Access,Evil Hat Productions,https://evilhat.itch.io/arecibo-foundry-vtt-access
-6/21/2024,Arecibo • Token Pack (DriveThruRPG),Evil Hat Productions,https://www.drivethrurpg.com/product/375909/Arecibo-o-Token-Pack?affiliate_id=1…
-6/21/2024,Arecibo • Token Pack (itch.io),Evil Hat Productions,https://evilhat.itch.io/arecibo-token-pack
-6/21/2024,Arecibo • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/arecibo-token-pack
-6/21/2024,Atomic Robo RPG,Evil Hat Productions,http://rpg.drivethrustuff.com/product/130204/Atomic-Robo-RPG?affiliate_id=144937
-6/21/2024,Atomic Robo RPG • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/atomic-robo-rpg-vtt-token-pack
-6/21/2024,Atomic Robo RPG • VTT Token Pack,Evil Hat Productions,https://evilhat.itch.io/atomic-robo-rpg-vtt-token-pack
-6/21/2024,Atomic Robo RPG: Majestic 12,Evil Hat Productions,http://drivethrurpg.com/product/185454/Atomic-Robo-RPG-Majestic-12?affiliate_id…
-6/21/2024,Authority and Reputation on the World Train,Evil Hat Productions,https://evilhat.com/wp-content/uploads/2022/04/World-Train-Authority.pdf
-6/21/2024,Behind the Walls • A World of Adventure for Fate Core,Evil Hat Productions,http://drivethrurpg.com/product/148388/Behind-the-Walls--A-World-of-Adventure-f…
-6/21/2024,Black Sun,Evil Hat Productions,https://evilhat.com/wp-content/uploads/2022/04/Black-Sun.pdf
-6/21/2024,Blood on the Trail (Foundry VTT),Evil Hat Productions,https://evilhat.itch.io/blood-on-the-trail-foundry-vtt-access
-6/21/2024,Blood on the Trail • A World of Adventure for Fate Core,Evil Hat Productions,http://drivethrurpg.com/product/193248/Blood-on-the-Trail--A-World-of-Adventure…
-6/21/2024,Blood on the Trail • Token Pack (DriveThruRPG),Evil Hat Productions,https://www.drivethrurpg.com/product/375919/Blood-on-the-Trail-o-Token-Pack?aff…
-6/21/2024,Blood on the Trail • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/blood-on-the-trail-vtt-token-pack
-6/21/2024,Deck of Fate,Evil Hat Productions,https://marketplace.roll20.net/browse/gameaddon/4980/the-deck-of-fate
-6/21/2024,Deep Dark Blue (Roll20),Evil Hat Productions,https://marketplace.roll20.net/browse/module/5756/deep-dark-blue
-6/21/2024,Deep Dark Blue • A World of Adventure for Fate Core,Evil Hat Productions,http://drivethrurpg.com/product/175636/Deep-Dark-Blue--A-World-of-Adventure-for…
-6/21/2024,Deep Dark Blue • Token Pack (DriveThruRPG),Evil Hat Productions,https://www.drivethrurpg.com/product/375926/Deep-Dark-Blue-o-Token-Pack?affilia…
-6/21/2024,Deep Dark Blue • Token Pack (itch.io),Evil Hat Productions,https://evilhat.itch.io/deep-dark-blue-token-pack
-6/21/2024,Do: Fate of the Flying Temple,Evil Hat Productions,http://drivethrurpg.com/product/185449/Do-Fate-of-the-Flying-Temple?affiliate_i…
-6/21/2024,Dresden Files Accelerated,Evil Hat Productions,http://www.drivethrurpg.com/product/213844/Dresden-Files-Accelerated?affiliate_…
-6/21/2024,Dresden Files RPG: Our World,Evil Hat Productions,http://rpg.drivethrustuff.com/product/80985/Dresden-Files-RPG-Our-World?affilia…
-6/21/2024,Dresden Files RPG: Paranet Papers,Evil Hat Productions,http://drivethrurpg.com/product/148232/Dresden-Files-RPG-Paranet-Papers?cPath=3…
-6/21/2024,Dresden Files RPG: Your Story,Evil Hat Productions,http://rpg.drivethrustuff.com/product/80984/Dresden-Files-RPG-Your-Story?affili…
-6/21/2024,Drops in a Pond,Evil Hat Productions,https://evilhat.com/wp-content/uploads/2022/04/Drops-in-a-Pond.pdf
-6/21/2024,Eagle Eyes • A World of Adventure for Fate Core,Evil Hat Productions,http://rpg.drivethrustuff.com/product/144754/Eagle-Eyes--A-World-of-Adventure-f…
-6/21/2024,Factions,Evil Hat Productions,https://evilhat.com/wp-content/uploads/2022/04/Factions.pdf
-6/21/2024,Fate Accelerated (Roll20),Evil Hat Productions,https://marketplace.roll20.net/browse/compendiumexpansion/18/fate-accelerated
-6/21/2024,Fate Accelerated/Core Conversion Guide,Evil Hat Productions,http://www.drivethrurpg.com/product/177639/Fate-Accelerated-Core-Conversion-Gui…
-6/21/2024,Fate Accessibility Toolkit,Evil Hat Productions,https://www.drivethrurpg.com/product/283738/Fate-Accessibility-Toolkit-o-Protot…
-6/21/2024,Fate Adversary Toolkit,Evil Hat Productions,https://www.drivethrurpg.com/product/219203/Fate-Adversary-Toolkit?affiliate_id…
-6/21/2024,Fate Condensed,Evil Hat Productions,https://www.drivethrurpg.com/product/302571/Fate-Condensed?affiliate_id=144937
-6/21/2024,Fate Core (Roll20),Evil Hat Productions,https://marketplace.roll20.net/browse/compendiumexpansion/3853/fate-core
-6/21/2024,Fate Horror Toolkit,Evil Hat Productions,http://drivethrurpg.com/product/242625/Fate-Horror-Toolkit?affiliate_id=144937
-6/21/2024,Fate of Cthulhu,Evil Hat Productions,https://www.drivethrurpg.com/product/300031/Fate-of-Cthulhu?affiliate_id=144937
-6/21/2024,Fate of Cthulhu Timeline • The Rise of Hastur,Evil Hat Productions,https://evilhat.itch.io/fate-of-cthulhu-timeline-the-rise-of-hastur
-6/21/2024,Fate of Cthulhu Timeline • The Rise of Hastur,Evil Hat Productions,https://www.drivethrurpg.com/product/377513/Fate-of-Cthulhu-Timeline-o-The-Rise…
-6/21/2024,Fate of Cthulhu Timeline • The Rise of the Azathoth,Evil Hat Productions,https://evilhat.itch.io/fate-of-cthulhu-timeline-the-rise-of-the-azathoth
-6/21/2024,Fate of Cthulhu Timeline • The Rise of the Basilisk,Evil Hat Productions,https://evilhat.itch.io/foctl-basilisk
-6/21/2024,Fate of Cthulhu Timeline • The Rise of the Quiet,Evil Hat Productions,https://evilhat.itch.io/foctl-quiet
-6/21/2024,Fate of Cthulhu Timeline • The Rise of Yig,Evil Hat Productions,https://evilhat.itch.io/foctl-yig
-6/21/2024,Fate of Cthulhu Timeline • The Rise of Yog-Sothoth,Evil Hat Productions,https://evilhat.itch.io/foctl-yogsothoth
-6/21/2024,Fate Space Toolkit,Evil Hat Productions,https://www.drivethrurpg.com/product/266197/Fate-Space-Toolkit-o-Prototype-Edit…
-6/21/2024,Fate Starter Bundle (Roll20),Evil Hat Productions,https://marketplace.roll20.net/browse/bundle/4793/fate-starter-bundle
-6/21/2024,Fate Worlds Bundle (Roll20),Evil Hat Productions,https://marketplace.roll20.net/browse/bundle/4796/fate-worlds-bundle
-6/21/2024,Fate Worlds Volume One: Worlds On Fire,Evil Hat Productions,https://www.drivethrurpg.com/product/119383/Fate-Worlds-Worlds-on-Fire?affiliat…
-6/21/2024,Fate Worlds Volume Two: Worlds In Shadow,Evil Hat Productions,https://www.drivethrurpg.com/product/119384/Fate-Worlds-Worlds-in-Shadow?affili…
-6/21/2024,Frontier Spirit • A World of Adventure for Fate Core,Evil Hat Productions,http://drivethrurpg.com/product/161674/Frontier-Spirit--A-World-of-Adventure-fo…
-6/21/2024,Ghost Planets • A World of Adventure for Fate Core,Evil Hat Productions,http://www.drivethrurpg.com/product/198258/Ghost-Planets--A-World-of-Adventure-…
-6/21/2024,Gods and Monsters • A World of Adventure for Fate Core,Evil Hat Productions,http://drivethrurpg.com/product/150889/Gods-and-Monsters--A-World-of-Adventure-…
-6/21/2024,Gods and Monsters • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/gods-and-monsters-vtt-art-pack
-6/21/2024,Gods and Monsters • VTT Art Pack (DriveThruRPG),Evil Hat Productions,https://www.drivethrurpg.com/product/376014/Gods-and-Monsters-o-VTT-Art-Pack?af…
-6/21/2024,Good Neighbors • A World of Adventure for Fate Core,Evil Hat Productions,http://drivethrurpg.com/product/191782/Good-Neighbors--A-World-of-Adventure-for…
-6/21/2024,Good Neighbors • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/good-neighbors-vtt-art-pack
-6/21/2024,Good Neighbors • VTT Art Pack (DriveThruRPG),Evil Hat Productions,https://www.drivethrurpg.com/product/376019/Good-Neighbors-o-VTT-Art-Pack?affil…
-6/21/2024,Grimoire • A World of Adventure for Fate Core,Evil Hat Productions,http://www.drivethrurpg.com/product/242162/Grimoire-o-A-World-of-Adventure-for-…
-6/21/2024,Grimoire • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/grimoire-vtt-art-pack
-6/21/2024,Grimoire • VTT Art Pack (DriveThruRPG),Evil Hat Productions,https://www.drivethrurpg.com/product/376036/Grimoire-o-VTT-Art-Pack?affiliate_i…
-6/21/2024,House of Bards • A World of Adventure for Fate Core,Evil Hat Productions,http://drivethrurpg.com/product/168186/House-of-Bards--A-World-of-Adventure-for…
-6/21/2024,Humanity and Magic,Evil Hat Productions,https://evilhat.com/wp-content/uploads/2022/04/Humanity-and-Magic.pdf
-6/21/2024,Iron Street Combat • A World of Adventure for Fate Core,Evil Hat Productions,https://www.drivethrurpg.com/product/273235/Iron-Street-Combat-o-A-World-of-Adv…
-6/21/2024,Iron Street Combat • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/iron-street-combat-vtt-art-pack
-6/21/2024,It's Not My Fault I'm Fantastic!,Evil Hat Productions,https://www.drivethrurpg.com/product/171228/Its-Not-My-Fault-Im-Fantastic?affil…
-6/21/2024,It's Not My Fault! (A Fate Accelerated Character & Situation Generator),Evil Hat Productions,https://www.drivethrurpg.com/product/162084/Its-Not-My-Fault-A-Fate-Accelerated…
-6/21/2024,Kaiju Incorporated,Evil Hat Productions,https://evilhat.com/product/kaiju-incorporated-the-rpg/
-6/21/2024,Knights of Invasion • A World of Adventure for Fate Core,Evil Hat Productions,http://www.drivethrurpg.com/product/179613/Knights-of-Invasion--A-World-of-Adve…
-6/21/2024,Knights of Invasion • Foundry VTT Access,Evil Hat Productions,https://evilhat.itch.io/knights-of-invasion-foundry-vtt-access
-6/21/2024,Knights of Invasion • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/knights-of-invasion-vtt-art-pack
-6/21/2024,Loose Threads • A World of Adventure for Fate Core,Evil Hat Productions,http://www.drivethrurpg.com/product/196127/Loose-Threads--A-World-of-Adventure-…
-6/21/2024,Loose Threads • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/loose-threads-vtt-art-pack
-6/21/2024,Masters of Umdaar • A World of Adventure for Fate Core,Evil Hat Productions,http://drivethrurpg.com/product/155458/Masters-of-Umdaar--A-World-of-Adventure-…
-6/21/2024,Morts • A World of Adventure for Fate Core,Evil Hat Productions,http://drivethrurpg.com/product/180960/Morts--A-World-of-Adventure-for-Fate-Cor…
-6/21/2024,Morts • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/morts-token-pack
-6/21/2024,Morts • VTT Token Pack,Evil Hat Productions,https://evilhat.itch.io/morts-token-pack
-6/21/2024,Nest • A World of Adventure for Fate Core,Evil Hat Productions,http://www.drivethrurpg.com/product/153980/Nest--A-World-of-Adventure-for-Fate-…
-6/21/2024,Ngen Mapu • A World of Adventure for Fate Core,Evil Hat Productions,https://www.drivethrurpg.com/product/280947/Ngen-Mapu-o-A-World-of-Adventure-fo…
-6/21/2024,Ngen Mapu • Token Pack,Evil Hat Productions,https://evilhat.itch.io/ngen-mapu-token-pack
-6/21/2024,Ngen Mapu • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/ngen-mapu-token-pack
-6/21/2024,Nitrate City • A World of Adventure for Fate Core,Evil Hat Productions,http://drivethrurpg.com/product/184325/Nitrate-City--A-World-of-Adventure-for-F…
-6/21/2024,On The Wall • A World of Adventure for Fate Core,Evil Hat Productions,http://drivethrurpg.com/product/227542/On-the-Wall-o-A-World-of-Adventure-for-F…
-6/21/2024,Prism • A World of Adventure for Fate Core,Evil Hat Productions,http://drivethrurpg.com/product/218544/Prism-o-A-World-of-Adventure-for-Fate-Co…
-6/21/2024,Psychedemia • A World of Adventure for Fate Core,Evil Hat Productions,https://www.drivethrurpg.com/product/142732/Psychedemia-o-A-World-of-Adventure-…
-6/21/2024,Psychic Powers,Evil Hat Productions,https://evilhat.com/wp-content/uploads/2022/04/Psychic-Powers.pdf
-6/21/2024,Red Planet (Roll20),Evil Hat Productions,https://marketplace.roll20.net/browse/module/5771/red-planet
-6/21/2024,Red Planet • A World of Adventure for Fate Core,Evil Hat Productions,http://www.drivethrurpg.com/product/199932/Red-Planet--A-World-of-Adventure-for…
-6/21/2024,Red Planet • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/red-planet-vtt-token-pack
-6/21/2024,Red Planet • VTT Token Pack,Evil Hat Productions,https://evilhat.itch.io/red-planet-vtt-token-pack
-6/21/2024,Romance in the Air • A World of Adventure for Fate Core,Evil Hat Productions,https://www.drivethrurpg.com/product/141360/Romance-in-the-Air-o-A-World-of-Adv…
-6/21/2024,Romance in the Air • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/romance-in-the-air-vtt-token-pack
-6/21/2024,Romance in the Air • VTT Token Pack,Evil Hat Productions,https://evilhat.itch.io/romance-in-the-air-vtt-token-pack
-6/21/2024,Sails Full of Stars • A World of Adventure for Fate Core,Evil Hat Productions,http://www.drivethrurpg.com/product/150022/Sails-Full-of-Stars--A-World-of-Adve…
-6/21/2024,Save Game • A World of Adventure for Fate Core,Evil Hat Productions,https://www.drivethrurpg.com/product/139030/Save-Game-o-A-World-of-Adventure-fo…
-6/21/2024,Secrets of Cats (Roll20),Evil Hat Productions,https://marketplace.roll20.net/browse/module/5754/the-secrets-of-cats
-6/21/2024,Shadow of the Century,Evil Hat Productions,https://www.drivethrurpg.com/product/266506/Shadow-of-the-Century?affiliate_id=…
-6/21/2024,Skill Prompt Cards for Fate,Evil Hat Productions,https://www.drivethrurpg.com/product/181580/Skill-Prompt-Cards-for-Fate?affilia…
-6/21/2024,SLIP • A World of Adventure for Fate Core,Evil Hat Productions,http://drivethrurpg.com/product/157267/SLIP--A-World-of-Adventure-for-Fate-Core…
-6/21/2024,So the Story Goes • A World of Adventure for Fate Core,Evil Hat Productions,http://www.drivethrurpg.com/product/221389/So-the-Story-Goes-o-A-World-of-Adven…
-6/21/2024,Straw Boss • A World of Adventure for Fate Core,Evil Hat Productions,http://www.drivethrurpg.com/product/223557/Straw-Boss-o-A-World-of-Adventure-fo…
-6/21/2024,Tachyon Squadron,Evil Hat Productions,https://www.drivethrurpg.com/product/254476/Tachyon-Squadron?affiliate_id=144937
-6/21/2024,Tachyon Squadron • Inside the Dominion of Unity,Evil Hat Productions,https://www.drivethrurpg.com/product/290896/Tachyon-Squadron-o-Inside-the-Domin…
-6/21/2024,Tachyon Squadron • Spaceship Construction Toolkit,Evil Hat Productions,https://www.drivethrurpg.com/product/310688/Tachyon-Squadron-o-Spaceship-Constr…
-6/21/2024,Tachyon Squadron • Starfighter Academy,Evil Hat Productions,https://www.drivethrurpg.com/product/287745/Tachyon-Squadron-o-Starfighter-Acad…
-6/21/2024,Tachyon Squadron • Those Who Were Here Before,Evil Hat Productions,https://www.drivethrurpg.com/product/265448/Tachyon-Squadron-o-Those-Who-Were-H…
-6/21/2024,Tachyon Squadron • VTT Art Pack,Evil Hat Productions,https://www.drivethrurpg.com/product/376231/Tachyon-Squadron-o-VTT-Art-Pack?aff…
-6/21/2024,The Agency • A World of Adventure for Fate Core,Evil Hat Productions,https://www.drivethrurpg.com/product/236183/The-Agency-o-A-World-of-Adventure-f…
-6/21/2024,The Clockwinders • A World of Adventure for Fate Core,Evil Hat Productions,https://www.drivethrurpg.com/product/266187/The-Clockwinders-o-A-World-of-Adven…
-6/21/2024,The Clockwinders • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/the-clockwinders-vtt-art-pack
-6/21/2024,The Clockwinders VTT Art Pack (DriveThruRPG),Evil Hat Productions,https://www.drivethrurpg.com/product/375922/The-Clockwinders-VTT-Art-Pack?affil…
-6/21/2024,The Crisp Line • A World of Adventure for Fate Core,Evil Hat Productions,https://www.drivethrurpg.com/product/252793/The-Crisp-Line-o-A-World-of-Adventu…
-6/21/2024,The Crisp Line • Token Pack (DriveThruRPG),Evil Hat Productions,https://www.drivethrurpg.com/product/375924/The-Crisp-Line-o-Token-Pack?affilia…
-6/21/2024,The Crisp Line • Token Pack (itch.io),Evil Hat Productions,https://evilhat.itch.io/the-crisp-line-token-pack
-6/21/2024,The Ministry • A World of Adventure for Fate Core,Evil Hat Productions,http://www.drivethrurpg.com/product/243951/The-Ministry-o-A-World-of-Adventure-…
-6/21/2024,The Ministry • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/the-ministry-vtt-art-pack
-6/21/2024,The Ministry • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/the-ministry-vtt-art-pack
-6/21/2024,The Secrets of Cats (Foundry VTT),Evil Hat Productions,https://evilhat.itch.io/the-secrets-of-cats-foundry-vtt-access
-6/21/2024,The Secrets of Cats • A World of Adventure for Fate Core,Evil Hat Productions,https://www.drivethrurpg.com/product/134533/The-Secrets-of-Cats-o-A-World-of-Ad…
-6/21/2024,The Three Rocketeers • A World of Adventure for Fate Core,Evil Hat Productions,http://drivethrurpg.com/product/166281/The-Three-Rocketeers--A-World-of-Adventu…
-6/21/2024,The Three Rocketeers • Token Pack (DriveThruRPG),Evil Hat Productions,https://www.drivethrurpg.com/product/375907/The-Three-Rocketeers-o-Token-Pack?a…
-6/21/2024,The Three Rocketeers • Token Pack (itch.io),Evil Hat Productions,https://evilhat.itch.io/the-three-rocketeers-token-pack
-6/21/2024,The Three Rocketeers • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/the-three-rocketeers-token-pack
-6/21/2024,The Way of the Pukona • A World of Adventure for Fate Core,Evil Hat Productions,https://www.drivethrurpg.com/product/248009/The-Way-of-the-Pukona-o-A-World-of-…
-6/21/2024,The Way of the Pukona • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/the-way-of-the-pukona-vtt-art-pack
-6/21/2024,The Way of the Pukona • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/the-way-of-the-pukona-vtt-art-pack
-6/21/2024,Til Dawn • A World of Adventure for Fate Core,Evil Hat Productions,https://www.drivethrurpg.com/product/270927/Til-Dawn-o-A-World-of-Adventure-for…
-6/21/2024,Til Dawn • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/til-dawn-vtt-art-pack
-6/21/2024,Under the Table • A World of Adventure for Fate Core,Evil Hat Productions,http://www.drivethrurpg.com/product/189229/Under-the-Table--A-World-of-Adventur…
-6/21/2024,Uprising: Revolutionary Messages,Evil Hat Productions,https://www.drivethrurpg.com/product/291069/Uprising-Revolutionary-Messages?aff…
-6/21/2024,Uprising: The Dystopian Universe RPG,Evil Hat Productions,https://www.drivethrurpg.com/product/252231/Uprising-The-Dystopian-Universe-RPG…
-6/21/2024,Uranium Chef • A World of Adventure for Fate Core,Evil Hat Productions,http://www.drivethrurpg.com/product/205720/Uranium-Chef--A-World-of-Adventure-f…
-6/21/2024,Uranium Chef • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/uranium-chef-vtt-art-pack
-6/21/2024,Venture City • Token Pack (DriveThruRPG),Evil Hat Productions,https://www.drivethrurpg.com/product/373907/Venture-City-o-Token-Pack?affiliate…
-6/21/2024,Venture City • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/venture-city-vtt-token-pack
-6/21/2024,Venture City • VTT Token Pack (itch.io),Evil Hat Productions,https://evilhat.itch.io/venture-city-vtt-token-pack
-6/21/2024,Venture City Stories • A World of Adventure for Fate Core,Evil Hat Productions,https://www.drivethrurpg.com/product/127246/Venture-City-o-A-Superpunk-Sourcebo…
-6/21/2024,Very Large Monsters,Evil Hat Productions,https://evilhat.com/wp-content/uploads/2022/04/Giant-Monsters.pdf
-6/21/2024,War of Ashes: Fate of Agaptus,Evil Hat Productions,http://drivethrurpg.com/product/157134/War-of-Ashes-Fate-of-Agaptus?affiliate_i…
-6/21/2024,Weird World News • A World of Adventure for Fate Core,Evil Hat Productions,https://www.drivethrurpg.com/product/251127/Weird-World-News?affiliate_id=144937
-6/21/2024,Weird World News • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/weird-world-news-vtt-art-pack
-6/21/2024,Wolf's Head • A World of Adventure for Fate Core,Evil Hat Productions,https://www.drivethrurpg.com/product/275626/Wolfs-Head-o-A-World-of-Adventure-f…
-6/21/2024,Wolf's Head • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/wolfs-head-vtt-art-pack
-6/21/2024,Words of Power,Evil Hat Productions,https://evilhat.com/wp-content/uploads/2022/04/Words-of-Power.pdf
-6/21/2024,Young Centurions,Evil Hat Productions,http://drivethrurpg.com/product/185457/Young-Centurions?affiliate_id=144937
-6/21/2024,Iron Edda: War of Metal and Bone,Exploding Rogue,https://www.drivethrurpg.com/product/137962/Iron-Edda-War-of-Metal-and-Bone?aff…
-6/21/2024,Modular Magic,Exploding Rogue,https://www.drivethrurpg.com/product/352664/Modular-Magic?affiliate_id=144937
-6/21/2024,[FAE] Villains Accelerated,Fainting Goat Games,http://drivethrurpg.com/product/134994/FAEVillains-Accelerated?affiliate_id=144…
-6/21/2024,Arthur Lives for Fate Core,Fainting Goat Games,http://www.drivethrurpg.com/product/232408/Arthur-Lives-for-Fate-Core?affiliate…
-6/21/2024,Extreme Earth Campaign Setting (FAE version),Fainting Goat Games,http://www.drivethrurpg.com/product/144388/FAE-Extreme-Earth-Campaign-Setting?a…
-6/21/2024,Fari.app,Fari.app,https://fari.app/
-6/21/2024,Return to the Stars Core Game,Festive Ninja,https://msabalau.itch.io/return-to-the-stars-rpg
-6/21/2024,The Stellar Beacon 2: Sci-Fi Gaming and essays on Fanfiction and Optimism,Festive Ninja,https://msabalau.itch.io/stellar-beacon-2
-6/21/2024,The Stellar Beacon: Hopepunk Issue,Festive Ninja,https://msabalau.itch.io/the-stellar-beacon-hopepunk
-6/21/2024,The Stellar Beacon: Serendipity,Festive Ninja,https://msabalau.itch.io/the-stellar-beacon-serendipity
-6/21/2024,The Stellar Beacon: Trickster Issue,Festive Ninja,https://msabalau.itch.io/trickster
-6/21/2024,Four-Color FAE,Four-Color FAE,https://www.drivethrurpg.com/product/150994/FourColor-FAE?affiliate_id=144937
-6/21/2024,Rockalypse,Four-in-Hand Games,http://www.drivethrurpg.com/product/204869/Rockalypse?affiliate_id=144937
-6/21/2024,Bulldogs! Fate Core Edition,Galileo Games,http://www.drivethrurpg.com/product/166518/Bulldogs-Fate-Core-Edition?affiliate…
-6/21/2024,The Ministry Initiative,Galileo Games,https://www.drivethrurpg.com/product/134517/The-Ministry-Initiative?affiliate_i…
-6/21/2024,Flatline,Gallant Knight Games,https://www.drivethrurpg.com/product/281193/Flatline?affiliate_id=144937
-6/21/2024,iHunt Abbreviated Reference,Gourmelee Games,https://gourmeleegames.itch.io/ihunt-abbreviated-reference
-6/21/2024,Fate Freeport Companion,Green Ronin,http://rpg.drivethrustuff.com/product/120298/Fate-Freeport-Companion?affiliate_…
-6/21/2024,Interface Zero 2.0: Fate Edition,Gun Metal Games,http://drivethrurpg.com/product/186125/Interface-Zero-20-Fate-Edition?affiliate…
-6/21/2024,Warsong Second Edition Core,Higher Grounds,http://www.drivethrurpg.com/product/240868/Warsong-Second-Edition-Core?affiliat…
-6/21/2024,Strange Stars Fate Rule Book,Hydra Cooperative,http://drivethrurpg.com/product/165972/Strange-Stars-Fate-Rule-Book?affiliate_i…
-6/21/2024,Unwritten: Adventures in the Ages of Myst and Beyond,InkWorks Productions,http://www.drivethrurpg.com/product/146509/Unwritten-Adventures-in-the-Ages-of-…
-6/21/2024,Inverse World Accelerated,Jacob Randolph,https://www.drivethrurpg.com/product/132426/Inverse-World-Accelerated?affiliate…
-6/21/2024,RPG Note Cards (For playing Fate Core and similar games online),Jan Tauš,http://fate.masac.cz/
-6/21/2024,In Thoth's Wake! - Zine Quest Edition!,Jon Smejkal,https://www.drivethrurpg.com/product/267778?affiliate_id=144937
-6/21/2024,"Shardland - Muskets, Blades and Words of Power",Judith and Christian Vogt,https://www.drivethrurpg.com/product/209441/Shardland--Muskets-Blades-and-Words…
-6/21/2024,El libro de Hanz: la guía para jugar Fate (Book of Hanz fan translation),La esquina del rol,https://laesquinadelrol.com/2021/07/29/librodehanz-epub/
-6/21/2024,London After Nightfall,Leo Winstead,https://www.drivethrurpg.com/product/297490/London-After-Nightfall?affiliate_id…
-6/21/2024,Mill City Heroes,Leo Winstead,https://www.drivethrurpg.com/product/231480/Mill-City-Heroes?affiliate_id=144937
-6/21/2024,Breakfast Cult,Liberi Gothica Games,http://www.drivethrurpg.com/product/182520/Breakfast-Cult?affiliate_id=144937
-6/21/2024,Game Over - A Breakfast Cult Expansion,Liberi Gothica Games,https://www.drivethrurpg.com/product/237239/Game-Over--A-Breakfast-Cult-Expansi…
-6/21/2024,#iHunt: The RPG,Machine Age Productions,https://www.drivethrurpg.com/product/298255/iHunt-The-RPG?affiliate_id=144937
-6/21/2024,Apotheosis Drive X - Fate-Powered Mecha RPG - HD Mix,Machine Age Productions,https://www.drivethrurpg.com/product/147795/Apotheosis-Drive-X--FatePowered-Mec…
-6/21/2024,Titan Hunt,Magnus Hansen,https://www.drivethrurpg.com/product/283664/Titan-Hunt?affiliate_id=144937
-6/21/2024,Wicked Fate,Magpie Games,https://www.drivethrurpg.com/product/269613/Wicked-Fate?affiliate_id=144937
-6/21/2024,Baroque Space Opera,Mark Kowaliszyn,http://www.drivethrurpg.com/product/156171/Baroque-Space-Opera?affiliate_id=144…
-6/21/2024,Achtung! Cthulhu: Investigator's Guide - Fate Core,Modiphius,https://www.drivethrurpg.com/product/131134/Achtung-Cthulhu-Investigators-Guide…
-6/21/2024,Mindjammer - Hearts & Minds Adventure,Modiphius,http://drivethrurpg.com/product/148519/Mindjammer--Hearts--Minds-Adventure?affi…
-6/21/2024,Mindjammer - The City People,Modiphius,https://www.drivethrurpg.com/product/180185/Mindjammer--The-City-People?affilia…
-6/21/2024,Mindjammer - The Roleplaying Game,Modiphius,http://www.drivethrurpg.com/product/128331/Mindjammer--The-Roleplaying-Game?aff…
-6/21/2024,Mindjammer – Transhuman Adventure in the Second Age of Space,Modiphius,https://www.drivethrurpg.com/product/128331/Mindjammer--The-Roleplaying-Game?af…
-6/21/2024,Mindjammer: Children of Orion—the Venu Sourcebook,Modiphius,http://www.drivethrurpg.com/product/224933/Mindjammer-Children-of-Orionthe-Venu…
-6/21/2024,Mindjammer: The Core Worlds Sourcebook,Modiphius,http://www.drivethrurpg.com/product/225695/Mindjammer-The-Core-Worlds-Sourceboo…
-6/21/2024,Mindjammer: The Mindjammer Companion,Modiphius,http://www.drivethrurpg.com/product/225696/Mindjammer-The-Mindjammer-Companion?…
-6/21/2024,MINDJAMMER: The Player's Guide,Modiphius,http://www.drivethrurpg.com/product/226561/MINDJAMMER-The-Players-Guide?affilia…
-6/21/2024,True Crime,Monkey Mind Games,https://www.drivethrurpg.com/en/product/315482?affiliate_id=144937
-6/21/2024,Carnival of Dreams,MonkeyBlood Design,https://www.drivethrurpg.com/product/228248/Carnival-of-Dreams-Fate?affiliate_i…
-6/21/2024,High Fantasy Magic: A Simple Magic System for Fate Core & Accelerated,Nathan Hare,http://www.drivethrurpg.com/product/199567/High-Fantasy-Magic-A-Simple-Magic-Sy…
-6/21/2024,Crashing Beasts & Crumbling Halls,Nothing Ventured Games,https://www.patreon.com/posts/43700788
-6/21/2024,It's Element-ary!,Nothing Ventured Games,http://www.drivethrurpg.com/product/179669/Its-Elementary?affiliate_id=144937
-6/21/2024,Strange Voyages,Occult Moon Games,http://www.drivethrurpg.com/product/141891/Strange-Voyages?affiliate_id=144937
-6/21/2024,Smoke and Glass,Phoenix Outlaw Productions,https://www.drivethrurpg.com/product/204213/Smoke-and-Glass?affiliate_id=144937
-6/21/2024,Space Cats — The Universe's Cutest Roleplaying Game,Pluma Press,https://www.drivethrurpg.com/product/343245/Space-Cats--The-Universes-Cutest-Ro…
-6/21/2024,Eclipse Phase: Transhumanity's Fate,Posthuman Studios LLC,http://www.drivethrurpg.com/product/176939?affiliate_id=144937
-6/21/2024,True Crime,Pugnacious Games,https://www.drivethrurpg.com/product/315482/True-Crime?affiliate_id=144937
-6/21/2024,The Way into Fate,Radar Avenue Press,https://www.drivethrurpg.com/product/179962/The-Way-into-Fate?affiliate_id=1449…
-6/21/2024,Fate Core Folio (iOS),Radical Bomb LLC,https://apps.apple.com/us/app/fate-core-folio/id622434362
-6/21/2024,Jadepunk Tales: Vigilance Committee Volume One,Reroll Productions,http://www.drivethrurpg.com/product/131898/Jadepunk-Tales-Vigilance-Committee-V…
-6/21/2024,Jadepunk Tales: Vigilance Committee Volume Two,Reroll Productions,http://www.drivethrurpg.com/product/139878/Jadepunk-Tales-Vigilance-Committee-V…
-6/21/2024,Jadepunk: Tales From Kausao City,Reroll Productions,https://www.drivethrurpg.com/product/127543/Jadepunk-Tales-From-Kausao-City?aff…
-6/21/2024,Jadetech: Black Jade,Reroll Productions,http://www.drivethrurpg.com/product/167648/Jadetech-Black-Jade?affiliate_id=144…
-6/21/2024,Jadetech: Blue Jade,Reroll Productions,http://www.drivethrurpg.com/product/144127/Jadetech-Blue-Jade?affiliate_id=1449…
-6/21/2024,Jadetech: Green Jade,Reroll Productions,http://www.drivethrurpg.com/product/132547/Jadetech-Green-Jade?affiliate_id=144…
-6/21/2024,Jadetech: Red Jade,Reroll Productions,http://www.drivethrurpg.com/product/134557/Jadetech-Red-Jade?affiliate_id=144937
-6/21/2024,Jadetech: White Jade,Reroll Productions,http://www.drivethrurpg.com/product/155098/Jadetech-White-Jade?affiliate_id=144…
-6/21/2024,Naramel: Jadepunk Martial Supplement,Reroll Productions,http://www.drivethrurpg.com/product/141611/Naramel-Jadepunk-Martial-Supplement?…
-6/21/2024,Shadowcraft: The Glamour War,Reroll Productions,http://www.drivethrurpg.com/product/183946/Shadowcraft-The-Glamour-War?affiliat…
-6/21/2024,The Secrets of Cats: Animals & Threats,Richard Bellingham,http://www.drivethrurpg.com/product/147773/The-Secrets-of-Cats-Animals--Threats…
-6/21/2024,The Secrets of Cats: Feline Magic,Richard Bellingham,https://www.drivethrurpg.com/product/194834/The-Secrets-of-Cats-Feline-Magic?af…
-6/21/2024,The Demolished Ones,Rite Publishing,https://www.drivethrurpg.com/product/114289/The-Demolished-Ones-Fate?affiliate_…
-6/21/2024,Fate Fantastic Creatures,Rolepress,https://www.drivethrurpg.com/product/359590/Fate-Fantastic-Creatures?affiliate_…
-6/21/2024,Fate Plus Cyberpunk,Rolepress,https://www.drivethrurpg.com/product/387323/Fate-Plus-Cyberpunk?affiliate_id=14…
-6/21/2024,Fate Plus Vikings,Rolepress,https://www.drivethrurpg.com/product/373817/Fate-Plus-Vikings?affiliate_id=1449…
-6/21/2024,Fate Dice (Android),RPG Automails,https://play.google.com/store/apps/details?id=com.rpgautomails.fatedice&hl=en_US
-6/21/2024,Fateful Concepts: Character Aspects,Ryan Macklin,https://www.drivethrurpg.com/product/130530/Fateful-Concepts-Character-Aspects?…
-6/21/2024,Fateful Concepts: Hacking Contests,Ryan Macklin,https://www.drivethrurpg.com/product/143487/Fateful-Concepts-Hacking-Contests?a…
-6/21/2024,Ice,Sandy Pug Games,https://www.drivethrurpg.com/product/210633/Ice-Fate?affiliate_id=144937
-6/21/2024,Magonomia: the RPG of Renaissance Wizardry,Shewstone Publishing,https://www.drivethrurpg.com/product/366281/Magonomia-the-RPG-of-Renaissance-Wi…
-6/21/2024,Heavy Metal Thunder Mouse,Shoreless Skies Publishing,https://www.drivethrurpg.com/product/220180/Heavy-Metal-Thunder-Mouse?affiliate…
-6/21/2024,Rock 'n' Roll Sock Hop Mouse,Shoreless Skies Publishing,http://drivethrurpg.com/product/245886/Rock-n-Roll-Sock-Hop-Mouse?affiliate_id=…
-6/21/2024,Van Wizards vs The Mageocracy,SicklyGeek,https://jynjynx.itch.io/van-wizards
-6/21/2024,Bells of the Dark Carol,Silver Lantern Games,https://www.drivethrurpg.com/product/322012?affiliate_id=144937
-6/21/2024,Sandfair,Silver Lantern Games,https://www.drivethrurpg.com/product/293952?affiliate_id=144937
-6/21/2024,Shadow Over Inowek,Silver Lantern Games,https://www.drivethrurpg.com/product/261398?affiliate_id=144937
-6/21/2024,The Explorer's Guide to Escadus,Silver Lantern Games,https://www.drivethrurpg.com/product/304005?affiliate_id=144937
-6/21/2024,Writing Fate Content,Silver Lantern Games,https://www.drivethrurpg.com/product/358330/Writing-Fate-Content?affiliate_id=1…
-6/21/2024,Base Raiders,Slang Design,http://rpg.drivethrustuff.com/product/120708/Base-Raiders?affiliate_id=144937
-6/21/2024,New Superpowers: Glitched Reality,Slang Design,https://www.drivethrurpg.com/product/194113/New-Superpowers-Glitched-Reality?af…
-6/21/2024,Aeon Wave,SlyFlourish,http://rpg.drivethrustuff.com/product/124481/Aeon-Wave?affiliate_id=144937
-6/21/2024,Out of the Furnace,Smart Party Publishing,http://www.drivethrurpg.com/product/157414/Out-of-the-Furnace?affiliate_id=1449…
-6/21/2024,Fate of Cthulhu Timeline • The Ascellan Conspiracy,Spotless Dice Games,https://www.drivethrurpg.com/product/433507/Fate-of-Cthulhu-Timeline-o-The-Asce…
-6/21/2024,Fate Accompli: Erasable Notecards,Tangent Artists,https://tangentartists.storenvy.com/collections/63855-all-products/products/197…
-6/21/2024,Divine Instruments of Fate (3EG205),Third Eye Games,http://www.drivethrurpg.com/product/168247/Divine-Instruments-of-Fate-3EG205aff…
-6/21/2024,Part-Time Gods of Fate,Third Eye Games,http://drivethrurpg.com/product/152385/PartTime-Gods-of-Fate?affiliate_id=144937
-6/21/2024,Solarpunk 2050,Thorsten Sick,https://www.drivethrurpg.com/product/443881/Solarpunk-2050?affiliate_id=144937
-6/21/2024,Divine Blood: RPG Supplement,Thrythlind Books and Games,http://www.drivethrurpg.com/product/133609/Divine-Blood-RPG-Supplement?affiliat…
-6/21/2024,Paranormal Affairs Canada,Tom Hart,https://www.drivethrurpg.com/product/353681/Paranormal-Affairs-Canada?affiliate…
-6/21/2024,The Chronicles of Future Earth Player's Guide,Typhon Games,https://www.drivethrurpg.com/en/product/471763/the-chronicles-of-future-earth-p…
-6/21/2024,Fate Core Rules Presented by Up to 4 Players (Comic summary of the Rules),Up to 4 Players,https://www.uptofourplayers.com/fate-core-rules/
-6/21/2024,Tianxia Accelerated,Vigilance Press,https://www.drivethrurpg.com/product/142131/Tianxia-Accelerated?affiliate_id=14…
-6/21/2024,"Tianxia: Blood, Silk & Jade",Vigilance Press,https://www.drivethrurpg.com/product/126883/Tianxia-Blood-Silk--Jade?affiliate_…
-6/21/2024,"Tianxia: Spirits, Beasts & Spells",Vigilance Press,http://www.drivethrurpg.com/product/188855/Tianxia-Spirits-Beasts--Spells?affil…
-6/21/2024,"Tianxia: War, Iron & Stone",Vigilance Press,http://www.drivethrurpg.com/product/202396/Tianxia-War-Iron--Stone?affiliate_id…
-6/21/2024,Aces in Space,Vogt & Vriends,https://www.drivethrurpg.com/product/317497/Aces-In-Space?affiliate_id=144937
-6/21/2024,Oubliette Second Edition,Voidspiral Entertainment,http://www.drivethrurpg.com/product/204460/Oubliette-Second-Edition?affiliate_i…
-6/21/2024,Diaspora,VSCA Publishing,http://drivethrurpg.com/product/79933/Diaspora?affiliate_id=144937
-6/21/2024,Wearing the Cape: The Roleplaying Game,Wearing the Cape Productions,https://www.drivethrurpg.com/product/210012/Wearing-the-Cape-The-Roleplaying-Ga…
-6/21/2024,"Crestfallen, A Bronze Age Fantasy RPG",White Rose Games,http://www.drivethrurpg.com/product/176630/Crestfallen-RPG?affiliate_id=144937
-6/21/2024,Once Upon a Crime,Wooden Vampire Games,http://www.drivethrurpg.com/product/171284/Once-Upon-a-Crime?affiliate_id=144937
-6/21/2024,Age of Arthur,Wordplay Games,http://www.drivethrurpg.com/product/111752?affiliate_id=144937
-6/21/2024,Time of the Wolves,Wordplay Games,http://www.drivethrurpg.com/product/149507?affiliate_id=144937
-6/21/2024,Strays!,Wordsmith Games LLC,http://www.drivethrurpg.com/product/169261/Strays?affiliate_id=144937
-6/21/2024,Mecha vs Kaiju: A Sci-Fi Anime RPG for Fate Core,WrightWerx,https://www.drivethrurpg.com/product/141809/Mecha-vs-Kaiju-Fate-Core?affiliate_…
-6/21/2024,Mecha vs Kaiju: Big Book of Kaiju - Land (Fate Core),WrightWerx,http://www.drivethrurpg.com/product/183921/Mecha-vs-Kaiju-Big-Book-of-Kaiju--La…
-6/21/2024,Mecha vs Kaiju: Big Book of Kaiju - Strange (Fate Core),WrightWerx,http://www.drivethrurpg.com/product/216360/Mecha-vs-Kaiju-Big-Book-of-Kaiju--St…
-6/21/2024,Mecha vs Kaiju: Kaijupunk 202X,WrightWerx,https://www.drivethrurpg.com/product/335925/Mecha-vs-Kaiju-Kaijupunk-202X?affil…
-6/21/2024,Mecha vs Kaiju: Sensational Sentai Squad GO!,WrightWerx,http://www.rpgnow.com/product/208158/Mecha-vs-Kaiju-Sensational-Sentai-Squad-GO…
-6/21/2024,Mecha vs Kaiju: Steam and Steel - A Fate Steampunk Supplement,WrightWerx,http://drivethrurpg.com/product/183915/Mecha-vs-Kaiju-Steam-and-Steel--A-Fate-S…
-6/21/2024,Michtim for Fate,Zev Mir,https://grimogre.itch.io/michtim-fate
+Product title,Publisher Name,Link to the product
+Aether Sea • A World of Adventure for Fate Core,Evil Hat Productions,http://rpg.drivethrustuff.com/product/139872/Aether-Sea--A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+Almbrecht After Dark • A World of Adventure for Fate Core,Evil Hat Productions,https://www.drivethrurpg.com/product/263582/Almbrecht-After-Dark?affiliate_id=144937
+Andromeda • A World of Adventure for Fate Core,Evil Hat Productions,https://www.drivethrurpg.com/product/202271/Andromeda--A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+Arecibo • A World of Adventure for Fate Core,Evil Hat Productions,http://drivethrurpg.com/product/240445/Arecibo-o-A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+Arecibo • Foundry VTT Access,Evil Hat Productions,https://evilhat.itch.io/arecibo-foundry-vtt-access
+Arecibo • Token Pack (DriveThruRPG),Evil Hat Productions,https://www.drivethrurpg.com/product/375909/Arecibo-o-Token-Pack?affiliate_id=144937
+Arecibo • Token Pack (itch.io),Evil Hat Productions,https://evilhat.itch.io/arecibo-token-pack
+Arecibo • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/arecibo-token-pack
+Atomic Robo RPG,Evil Hat Productions,http://rpg.drivethrustuff.com/product/130204/Atomic-Robo-RPG?affiliate_id=144937
+Atomic Robo RPG • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/atomic-robo-rpg-vtt-token-pack
+Atomic Robo RPG • VTT Token Pack,Evil Hat Productions,https://evilhat.itch.io/atomic-robo-rpg-vtt-token-pack
+Atomic Robo RPG: Majestic 12,Evil Hat Productions,http://drivethrurpg.com/product/185454/Atomic-Robo-RPG-Majestic-12?affiliate_id=144937
+Authority and Reputation on the World Train,Evil Hat Productions,https://evilhat.com/wp-content/uploads/2022/04/World-Train-Authority.pdf
+Behind the Walls • A World of Adventure for Fate Core,Evil Hat Productions,http://drivethrurpg.com/product/148388/Behind-the-Walls--A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+Black Sun,Evil Hat Productions,https://evilhat.com/wp-content/uploads/2022/04/Black-Sun.pdf
+Blood on the Trail (Foundry VTT),Evil Hat Productions,https://evilhat.itch.io/blood-on-the-trail-foundry-vtt-access
+Blood on the Trail • A World of Adventure for Fate Core,Evil Hat Productions,http://drivethrurpg.com/product/193248/Blood-on-the-Trail--A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+Blood on the Trail • Token Pack (DriveThruRPG),Evil Hat Productions,https://www.drivethrurpg.com/product/375919/Blood-on-the-Trail-o-Token-Pack?affiliate_id=144937
+Blood on the Trail • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/blood-on-the-trail-vtt-token-pack
+Deck of Fate,Evil Hat Productions,https://marketplace.roll20.net/browse/gameaddon/4980/the-deck-of-fate
+Deep Dark Blue (Roll20),Evil Hat Productions,https://marketplace.roll20.net/browse/module/5756/deep-dark-blue
+Deep Dark Blue • A World of Adventure for Fate Core,Evil Hat Productions,http://drivethrurpg.com/product/175636/Deep-Dark-Blue--A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+Deep Dark Blue • Token Pack (DriveThruRPG),Evil Hat Productions,https://www.drivethrurpg.com/product/375926/Deep-Dark-Blue-o-Token-Pack?affiliate_id=144937
+Deep Dark Blue • Token Pack (itch.io),Evil Hat Productions,https://evilhat.itch.io/deep-dark-blue-token-pack
+Do: Fate of the Flying Temple,Evil Hat Productions,http://drivethrurpg.com/product/185449/Do-Fate-of-the-Flying-Temple?affiliate_id=144937
+Dresden Files Accelerated,Evil Hat Productions,http://www.drivethrurpg.com/product/213844/Dresden-Files-Accelerated?affiliate_id=144937
+Dresden Files RPG: Our World,Evil Hat Productions,http://rpg.drivethrustuff.com/product/80985/Dresden-Files-RPG-Our-World?affiliate_id=144937
+Dresden Files RPG: Paranet Papers,Evil Hat Productions,http://drivethrurpg.com/product/148232/Dresden-Files-RPG-Paranet-Papers?cPath=3924_19295&affiliate_id=144937
+Dresden Files RPG: Your Story,Evil Hat Productions,http://rpg.drivethrustuff.com/product/80984/Dresden-Files-RPG-Your-Story?affiliate_id=144937
+Drops in a Pond,Evil Hat Productions,https://evilhat.com/wp-content/uploads/2022/04/Drops-in-a-Pond.pdf
+Eagle Eyes • A World of Adventure for Fate Core,Evil Hat Productions,http://rpg.drivethrustuff.com/product/144754/Eagle-Eyes--A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+Factions,Evil Hat Productions,https://evilhat.com/wp-content/uploads/2022/04/Factions.pdf
+Fate Accelerated (Roll20),Evil Hat Productions,https://marketplace.roll20.net/browse/compendiumexpansion/18/fate-accelerated
+Fate Accelerated/Core Conversion Guide,Evil Hat Productions,http://www.drivethrurpg.com/product/177639/Fate-Accelerated-Core-Conversion-Guide?affiliate_id=144937
+Fate Accessibility Toolkit,Evil Hat Productions,https://www.drivethrurpg.com/product/283738/Fate-Accessibility-Toolkit-o-Prototype-Edition?affiliate_id=144937
+Fate Adversary Toolkit,Evil Hat Productions,https://www.drivethrurpg.com/product/219203/Fate-Adversary-Toolkit?affiliate_id=144937
+Fate Condensed,Evil Hat Productions,https://www.drivethrurpg.com/product/302571/Fate-Condensed?affiliate_id=144937
+Fate Core (Roll20),Evil Hat Productions,https://marketplace.roll20.net/browse/compendiumexpansion/3853/fate-core
+Fate Horror Toolkit,Evil Hat Productions,http://drivethrurpg.com/product/242625/Fate-Horror-Toolkit?affiliate_id=144937
+Fate of Cthulhu,Evil Hat Productions,https://www.drivethrurpg.com/product/300031/Fate-of-Cthulhu?affiliate_id=144937
+Fate of Cthulhu Timeline • The Rise of Hastur,Evil Hat Productions,https://evilhat.itch.io/fate-of-cthulhu-timeline-the-rise-of-hastur
+Fate of Cthulhu Timeline • The Rise of Hastur,Evil Hat Productions,https://www.drivethrurpg.com/product/377513/Fate-of-Cthulhu-Timeline-o-The-Rise-of-Hastur?affiliate_id=144937
+Fate of Cthulhu Timeline • The Rise of the Azathoth,Evil Hat Productions,https://evilhat.itch.io/fate-of-cthulhu-timeline-the-rise-of-the-azathoth
+Fate of Cthulhu Timeline • The Rise of the Basilisk,Evil Hat Productions,https://evilhat.itch.io/foctl-basilisk
+Fate of Cthulhu Timeline • The Rise of the Quiet,Evil Hat Productions,https://evilhat.itch.io/foctl-quiet
+Fate of Cthulhu Timeline • The Rise of Yig,Evil Hat Productions,https://evilhat.itch.io/foctl-yig
+Fate of Cthulhu Timeline • The Rise of Yog-Sothoth,Evil Hat Productions,https://evilhat.itch.io/foctl-yogsothoth
+Fate Space Toolkit,Evil Hat Productions,https://www.drivethrurpg.com/product/266197/Fate-Space-Toolkit-o-Prototype-Edition?affiliate_id=144937
+Fate Starter Bundle (Roll20),Evil Hat Productions,https://marketplace.roll20.net/browse/bundle/4793/fate-starter-bundle
+Fate Worlds Bundle (Roll20),Evil Hat Productions,https://marketplace.roll20.net/browse/bundle/4796/fate-worlds-bundle
+Fate Worlds Volume One: Worlds On Fire,Evil Hat Productions,https://www.drivethrurpg.com/product/119383/Fate-Worlds-Worlds-on-Fire?affiliate_id=144937
+Fate Worlds Volume Two: Worlds In Shadow,Evil Hat Productions,https://www.drivethrurpg.com/product/119384/Fate-Worlds-Worlds-in-Shadow?affiliate_id=144937
+Frontier Spirit • A World of Adventure for Fate Core,Evil Hat Productions,http://drivethrurpg.com/product/161674/Frontier-Spirit--A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+Ghost Planets • A World of Adventure for Fate Core,Evil Hat Productions,http://www.drivethrurpg.com/product/198258/Ghost-Planets--A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+Gods and Monsters • A World of Adventure for Fate Core,Evil Hat Productions,http://drivethrurpg.com/product/150889/Gods-and-Monsters--A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+Gods and Monsters • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/gods-and-monsters-vtt-art-pack
+Gods and Monsters • VTT Art Pack (DriveThruRPG),Evil Hat Productions,https://www.drivethrurpg.com/product/376014/Gods-and-Monsters-o-VTT-Art-Pack?affiliate_id=144937
+Good Neighbors • A World of Adventure for Fate Core,Evil Hat Productions,http://drivethrurpg.com/product/191782/Good-Neighbors--A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+Good Neighbors • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/good-neighbors-vtt-art-pack
+Good Neighbors • VTT Art Pack (DriveThruRPG),Evil Hat Productions,https://www.drivethrurpg.com/product/376019/Good-Neighbors-o-VTT-Art-Pack?affiliate_id=144937
+Grimoire • A World of Adventure for Fate Core,Evil Hat Productions,http://www.drivethrurpg.com/product/242162/Grimoire-o-A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+Grimoire • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/grimoire-vtt-art-pack
+Grimoire • VTT Art Pack (DriveThruRPG),Evil Hat Productions,https://www.drivethrurpg.com/product/376036/Grimoire-o-VTT-Art-Pack?affiliate_id=144937
+House of Bards • A World of Adventure for Fate Core,Evil Hat Productions,http://drivethrurpg.com/product/168186/House-of-Bards--A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+Humanity and Magic,Evil Hat Productions,https://evilhat.com/wp-content/uploads/2022/04/Humanity-and-Magic.pdf
+Iron Street Combat • A World of Adventure for Fate Core,Evil Hat Productions,https://www.drivethrurpg.com/product/273235/Iron-Street-Combat-o-A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+Iron Street Combat • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/iron-street-combat-vtt-art-pack
+It's Not My Fault I'm Fantastic!,Evil Hat Productions,https://www.drivethrurpg.com/product/171228/Its-Not-My-Fault-Im-Fantastic?affiliate_id=144937
+It's Not My Fault! (A Fate Accelerated Character & Situation Generator),Evil Hat Productions,https://www.drivethrurpg.com/product/162084/Its-Not-My-Fault-A-Fate-Accelerated-Character--Situation-Generator?affiliate_id=144937
+Kaiju Incorporated,Evil Hat Productions,https://evilhat.com/product/kaiju-incorporated-the-rpg/
+Knights of Invasion • A World of Adventure for Fate Core,Evil Hat Productions,http://www.drivethrurpg.com/product/179613/Knights-of-Invasion--A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+Knights of Invasion • Foundry VTT Access,Evil Hat Productions,https://evilhat.itch.io/knights-of-invasion-foundry-vtt-access
+Knights of Invasion • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/knights-of-invasion-vtt-art-pack
+Loose Threads • A World of Adventure for Fate Core,Evil Hat Productions,http://www.drivethrurpg.com/product/196127/Loose-Threads--A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+Loose Threads • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/loose-threads-vtt-art-pack
+Masters of Umdaar • A World of Adventure for Fate Core,Evil Hat Productions,http://drivethrurpg.com/product/155458/Masters-of-Umdaar--A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+Morts • A World of Adventure for Fate Core,Evil Hat Productions,http://drivethrurpg.com/product/180960/Morts--A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+Morts • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/morts-token-pack
+Morts • VTT Token Pack,Evil Hat Productions,https://evilhat.itch.io/morts-token-pack
+Nest • A World of Adventure for Fate Core,Evil Hat Productions,http://www.drivethrurpg.com/product/153980/Nest--A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+Ngen Mapu • A World of Adventure for Fate Core,Evil Hat Productions,https://www.drivethrurpg.com/product/280947/Ngen-Mapu-o-A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+Ngen Mapu • Token Pack,Evil Hat Productions,https://evilhat.itch.io/ngen-mapu-token-pack
+Ngen Mapu • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/ngen-mapu-token-pack
+Nitrate City • A World of Adventure for Fate Core,Evil Hat Productions,http://drivethrurpg.com/product/184325/Nitrate-City--A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+On The Wall • A World of Adventure for Fate Core,Evil Hat Productions,http://drivethrurpg.com/product/227542/On-the-Wall-o-A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+Prism • A World of Adventure for Fate Core,Evil Hat Productions,http://drivethrurpg.com/product/218544/Prism-o-A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+Psychedemia • A World of Adventure for Fate Core,Evil Hat Productions,https://www.drivethrurpg.com/product/142732/Psychedemia-o-A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+Psychic Powers,Evil Hat Productions,https://evilhat.com/wp-content/uploads/2022/04/Psychic-Powers.pdf
+Red Planet (Roll20),Evil Hat Productions,https://marketplace.roll20.net/browse/module/5771/red-planet
+Red Planet • A World of Adventure for Fate Core,Evil Hat Productions,http://www.drivethrurpg.com/product/199932/Red-Planet--A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+Red Planet • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/red-planet-vtt-token-pack
+Red Planet • VTT Token Pack,Evil Hat Productions,https://evilhat.itch.io/red-planet-vtt-token-pack
+Romance in the Air • A World of Adventure for Fate Core,Evil Hat Productions,https://www.drivethrurpg.com/product/141360/Romance-in-the-Air-o-A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+Romance in the Air • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/romance-in-the-air-vtt-token-pack
+Romance in the Air • VTT Token Pack,Evil Hat Productions,https://evilhat.itch.io/romance-in-the-air-vtt-token-pack
+Sails Full of Stars • A World of Adventure for Fate Core,Evil Hat Productions,http://www.drivethrurpg.com/product/150022/Sails-Full-of-Stars--A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+Save Game • A World of Adventure for Fate Core,Evil Hat Productions,https://www.drivethrurpg.com/product/139030/Save-Game-o-A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+Secrets of Cats (Roll20),Evil Hat Productions,https://marketplace.roll20.net/browse/module/5754/the-secrets-of-cats
+Shadow of the Century,Evil Hat Productions,https://www.drivethrurpg.com/product/266506/Shadow-of-the-Century?affiliate_id=144937
+Skill Prompt Cards for Fate,Evil Hat Productions,https://www.drivethrurpg.com/product/181580/Skill-Prompt-Cards-for-Fate?affiliate_id=144937
+SLIP • A World of Adventure for Fate Core,Evil Hat Productions,http://drivethrurpg.com/product/157267/SLIP--A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+So the Story Goes • A World of Adventure for Fate Core,Evil Hat Productions,http://www.drivethrurpg.com/product/221389/So-the-Story-Goes-o-A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+Straw Boss • A World of Adventure for Fate Core,Evil Hat Productions,http://www.drivethrurpg.com/product/223557/Straw-Boss-o-A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+Tachyon Squadron,Evil Hat Productions,https://www.drivethrurpg.com/product/254476/Tachyon-Squadron?affiliate_id=144937
+Tachyon Squadron • Inside the Dominion of Unity,Evil Hat Productions,https://www.drivethrurpg.com/product/290896/Tachyon-Squadron-o-Inside-the-Dominion-of-Unity?affiliate_id=144937
+Tachyon Squadron • Spaceship Construction Toolkit,Evil Hat Productions,https://www.drivethrurpg.com/product/310688/Tachyon-Squadron-o-Spaceship-Construction-Toolkit?affiliate_id=144937
+Tachyon Squadron • Starfighter Academy,Evil Hat Productions,https://www.drivethrurpg.com/product/287745/Tachyon-Squadron-o-Starfighter-Academy?affiliate_id=144937
+Tachyon Squadron • Those Who Were Here Before,Evil Hat Productions,https://www.drivethrurpg.com/product/265448/Tachyon-Squadron-o-Those-Who-Were-Here-Before?affiliate_id=144937
+Tachyon Squadron • VTT Art Pack,Evil Hat Productions,https://www.drivethrurpg.com/product/376231/Tachyon-Squadron-o-VTT-Art-Pack?affiliate_id=144937
+The Agency • A World of Adventure for Fate Core,Evil Hat Productions,https://www.drivethrurpg.com/product/236183/The-Agency-o-A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+The Clockwinders • A World of Adventure for Fate Core,Evil Hat Productions,https://www.drivethrurpg.com/product/266187/The-Clockwinders-o-A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+The Clockwinders • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/the-clockwinders-vtt-art-pack
+The Clockwinders VTT Art Pack (DriveThruRPG),Evil Hat Productions,https://www.drivethrurpg.com/product/375922/The-Clockwinders-VTT-Art-Pack?affiliate_id=144937
+The Crisp Line • A World of Adventure for Fate Core,Evil Hat Productions,https://www.drivethrurpg.com/product/252793/The-Crisp-Line-o-A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+The Crisp Line • Token Pack (DriveThruRPG),Evil Hat Productions,https://www.drivethrurpg.com/product/375924/The-Crisp-Line-o-Token-Pack?affiliate_id=144937
+The Crisp Line • Token Pack (itch.io),Evil Hat Productions,https://evilhat.itch.io/the-crisp-line-token-pack
+The Ministry • A World of Adventure for Fate Core,Evil Hat Productions,http://www.drivethrurpg.com/product/243951/The-Ministry-o-A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+The Ministry • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/the-ministry-vtt-art-pack
+The Ministry • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/the-ministry-vtt-art-pack
+The Secrets of Cats (Foundry VTT),Evil Hat Productions,https://evilhat.itch.io/the-secrets-of-cats-foundry-vtt-access
+The Secrets of Cats • A World of Adventure for Fate Core,Evil Hat Productions,https://www.drivethrurpg.com/product/134533/The-Secrets-of-Cats-o-A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+The Three Rocketeers • A World of Adventure for Fate Core,Evil Hat Productions,http://drivethrurpg.com/product/166281/The-Three-Rocketeers--A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+The Three Rocketeers • Token Pack (DriveThruRPG),Evil Hat Productions,https://www.drivethrurpg.com/product/375907/The-Three-Rocketeers-o-Token-Pack?affiliate_id=144937
+The Three Rocketeers • Token Pack (itch.io),Evil Hat Productions,https://evilhat.itch.io/the-three-rocketeers-token-pack
+The Three Rocketeers • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/the-three-rocketeers-token-pack
+The Way of the Pukona • A World of Adventure for Fate Core,Evil Hat Productions,https://www.drivethrurpg.com/product/248009/The-Way-of-the-Pukona-o-A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+The Way of the Pukona • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/the-way-of-the-pukona-vtt-art-pack
+The Way of the Pukona • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/the-way-of-the-pukona-vtt-art-pack
+Til Dawn • A World of Adventure for Fate Core,Evil Hat Productions,https://www.drivethrurpg.com/product/270927/Til-Dawn-o-A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+Til Dawn • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/til-dawn-vtt-art-pack
+Under the Table • A World of Adventure for Fate Core,Evil Hat Productions,http://www.drivethrurpg.com/product/189229/Under-the-Table--A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+Uprising: Revolutionary Messages,Evil Hat Productions,https://www.drivethrurpg.com/product/291069/Uprising-Revolutionary-Messages?affiliate_id=144937
+Uprising: The Dystopian Universe RPG,Evil Hat Productions,https://www.drivethrurpg.com/product/252231/Uprising-The-Dystopian-Universe-RPG?affiliate_id=144937
+Uranium Chef • A World of Adventure for Fate Core,Evil Hat Productions,http://www.drivethrurpg.com/product/205720/Uranium-Chef--A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+Uranium Chef • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/uranium-chef-vtt-art-pack
+Venture City • Token Pack (DriveThruRPG),Evil Hat Productions,https://www.drivethrurpg.com/product/373907/Venture-City-o-Token-Pack?affiliate_id=144937
+Venture City • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/venture-city-vtt-token-pack
+Venture City • VTT Token Pack (itch.io),Evil Hat Productions,https://evilhat.itch.io/venture-city-vtt-token-pack
+Venture City Stories • A World of Adventure for Fate Core,Evil Hat Productions,https://www.drivethrurpg.com/product/127246/Venture-City-o-A-Superpunk-Sourcebook-for-Fate-Core?affiliate_id=144937
+Very Large Monsters,Evil Hat Productions,https://evilhat.com/wp-content/uploads/2022/04/Giant-Monsters.pdf
+War of Ashes: Fate of Agaptus,Evil Hat Productions,http://drivethrurpg.com/product/157134/War-of-Ashes-Fate-of-Agaptus?affiliate_id=144937
+Weird World News • A World of Adventure for Fate Core,Evil Hat Productions,https://www.drivethrurpg.com/product/251127/Weird-World-News?affiliate_id=144937
+Weird World News • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/weird-world-news-vtt-art-pack
+Wolf's Head • A World of Adventure for Fate Core,Evil Hat Productions,https://www.drivethrurpg.com/product/275626/Wolfs-Head-o-A-World-of-Adventure-for-Fate-Core?affiliate_id=144937
+Wolf's Head • VTT Art Pack,Evil Hat Productions,https://evilhat.itch.io/wolfs-head-vtt-art-pack
+Words of Power,Evil Hat Productions,https://evilhat.com/wp-content/uploads/2022/04/Words-of-Power.pdf
+Young Centurions,Evil Hat Productions,http://drivethrurpg.com/product/185457/Young-Centurions?affiliate_id=144937
+Aeon Wave,SlyFlourish,http://rpg.drivethrustuff.com/product/124481/Aeon-Wave?affiliate_id=144937
+Fate Freeport Companion,Green Ronin,http://rpg.drivethrustuff.com/product/120298/Fate-Freeport-Companion?affiliate_id=144937
+Base Raiders,Slang Design,http://rpg.drivethrustuff.com/product/120708/Base-Raiders?affiliate_id=144937
+New Superpowers: Glitched Reality,Slang Design,https://www.drivethrurpg.com/product/194113/New-Superpowers-Glitched-Reality?affiliate_id=144937
+#iHunt: The RPG,Machine Age Productions,https://www.drivethrurpg.com/product/298255/iHunt-The-RPG?affiliate_id=144937
+Apotheosis Drive X - Fate-Powered Mecha RPG - HD Mix,Machine Age Productions,https://www.drivethrurpg.com/product/147795/Apotheosis-Drive-X--FatePowered-Mecha-RPG--HD-Mix?affiliate_id=144937
+Achtung! Cthulhu: Investigator's Guide - Fate Core,Modiphius,https://www.drivethrurpg.com/product/131134/Achtung-Cthulhu-Investigators-Guide--Fate-Core?affiliate_id=144937
+Mindjammer - Hearts & Minds Adventure,Modiphius,http://drivethrurpg.com/product/148519/Mindjammer--Hearts--Minds-Adventure?affiliate_id=144937
+Mindjammer - The City People,Modiphius,https://www.drivethrurpg.com/product/180185/Mindjammer--The-City-People?affiliate_id=144937
+Mindjammer - The Roleplaying Game,Modiphius,http://www.drivethrurpg.com/product/128331/Mindjammer--The-Roleplaying-Game?affiliate_id=144937
+Mindjammer – Transhuman Adventure in the Second Age of Space,Modiphius,https://www.drivethrurpg.com/product/128331/Mindjammer--The-Roleplaying-Game?affiliate_id=144937
+Mindjammer: Children of Orion—the Venu Sourcebook,Modiphius,http://www.drivethrurpg.com/product/224933/Mindjammer-Children-of-Orionthe-Venu-Sourcebook?affiliate_id=144937
+Mindjammer: The Core Worlds Sourcebook,Modiphius,http://www.drivethrurpg.com/product/225695/Mindjammer-The-Core-Worlds-Sourcebook?affiliate_id=144937
+Mindjammer: The Mindjammer Companion,Modiphius,http://www.drivethrurpg.com/product/225696/Mindjammer-The-Mindjammer-Companion?affiliate_id=144937
+MINDJAMMER: The Player's Guide,Modiphius,http://www.drivethrurpg.com/product/226561/MINDJAMMER-The-Players-Guide?affiliate_id=144937
+Tianxia Accelerated,Vigilance Press,https://www.drivethrurpg.com/product/142131/Tianxia-Accelerated?affiliate_id=144937
+"Tianxia: Blood, Silk & Jade",Vigilance Press,https://www.drivethrurpg.com/product/126883/Tianxia-Blood-Silk--Jade?affiliate_id=144937
+"Tianxia: Spirits, Beasts & Spells",Vigilance Press,http://www.drivethrurpg.com/product/188855/Tianxia-Spirits-Beasts--Spells?affiliate_id=144937
+"Tianxia: War, Iron & Stone",Vigilance Press,http://www.drivethrurpg.com/product/202396/Tianxia-War-Iron--Stone?affiliate_id=144937
+Jadepunk Tales: Vigilance Committee Volume One,Reroll Productions,http://www.drivethrurpg.com/product/131898/Jadepunk-Tales-Vigilance-Committee-Volume-One?affiliate_id=144937
+Jadepunk Tales: Vigilance Committee Volume Two,Reroll Productions,http://www.drivethrurpg.com/product/139878/Jadepunk-Tales-Vigilance-Committee-Volume-Two?affiliate_id=144937
+Jadepunk: Tales From Kausao City,Reroll Productions,https://www.drivethrurpg.com/product/127543/Jadepunk-Tales-From-Kausao-City?affiliate_id=144937
+Jadetech: Black Jade,Reroll Productions,http://www.drivethrurpg.com/product/167648/Jadetech-Black-Jade?affiliate_id=144937
+Jadetech: Blue Jade,Reroll Productions,http://www.drivethrurpg.com/product/144127/Jadetech-Blue-Jade?affiliate_id=144937
+Jadetech: Green Jade,Reroll Productions,http://www.drivethrurpg.com/product/132547/Jadetech-Green-Jade?affiliate_id=144937
+Jadetech: Red Jade,Reroll Productions,http://www.drivethrurpg.com/product/134557/Jadetech-Red-Jade?affiliate_id=144937
+Jadetech: White Jade,Reroll Productions,http://www.drivethrurpg.com/product/155098/Jadetech-White-Jade?affiliate_id=144937
+Naramel: Jadepunk Martial Supplement,Reroll Productions,http://www.drivethrurpg.com/product/141611/Naramel-Jadepunk-Martial-Supplement?affiliate_id=144937
+Shadowcraft: The Glamour War,Reroll Productions,http://www.drivethrurpg.com/product/183946/Shadowcraft-The-Glamour-War?affiliate_id=144937
+Dawning Star: Fate of Eos,Blue Devil Games,https://www.drivethrurpg.com/product/229377/Dawning-Star-Fate-of-Eos?affiliate_id=144937
+Unwritten: Adventures in the Ages of Myst and Beyond,InkWorks Productions,http://www.drivethrurpg.com/product/146509/Unwritten-Adventures-in-the-Ages-of-MYST-and-Beyond?affiliate_id=144937
+Amethyst: Accelerated,Dias Ex Machina,http://www.drivethrurpg.com/product/157056/Amethyst--Accelerated-Fate-Edition?affiliate_id=144937
+Amethyst: Destiny (Fate Edition),Dias Ex Machina,http://rpg.drivethrustuff.com/product/134037/Amethyst-Destiny-Fate-Edition?affiliate_id=144937
+Fate Core Character Journal,EldritchFire Press,http://rpg.drivethrustuff.com/product/118798/Fate-Core-Character-Journal?affiliate_id=144937
+Five Elements: A Fate Core Magic System,EldritchFire Press,https://www.drivethrurpg.com/product/132834/Five-Elements-A-Fate-Core-Magic-System?affiliate_id=144937
+Grim World,Boldly Games,https://boldlygames.com/
+Wicked Fate,Magpie Games,https://www.drivethrurpg.com/product/269613/Wicked-Fate?affiliate_id=144937
+The Day After Ragnarok: Fate Core Edition,Atomic Overmind Press,https://www.drivethrurpg.com/product/119680/The-Day-After-Ragnarok-Fate-Core-Edition?affiliate_id=144937
+Fateful Concepts: Character Aspects,Ryan Macklin,https://www.drivethrurpg.com/product/130530/Fateful-Concepts-Character-Aspects?affiliate_id=144937
+Fateful Concepts: Hacking Contests,Ryan Macklin,https://www.drivethrurpg.com/product/143487/Fateful-Concepts-Hacking-Contests?affiliate_id=144937
+Bulldogs! Fate Core Edition,Galileo Games,http://www.drivethrurpg.com/product/166518/Bulldogs-Fate-Core-Edition?affiliate_id=144937
+The Ministry Initiative,Galileo Games,https://www.drivethrurpg.com/product/134517/The-Ministry-Initiative?affiliate_id=144937
+Fate Acelerado,Ediciones conBarba,http://rpg.drivethrustuff.com/product/134320/Fate-Acelerado?affiliate_id=144937
+Iron Edda: War of Metal and Bone,Exploding Rogue,https://www.drivethrurpg.com/product/137962/Iron-Edda-War-of-Metal-and-Bone?affiliate_id=144937
+Modular Magic,Exploding Rogue,https://www.drivethrurpg.com/product/352664/Modular-Magic?affiliate_id=144937
+The Demolished Ones,Rite Publishing,https://www.drivethrurpg.com/product/114289/The-Demolished-Ones-Fate?affiliate_id=144937
+Inverse World Accelerated,Jacob Randolph,https://www.drivethrurpg.com/product/132426/Inverse-World-Accelerated?affiliate_id=144937
+Strange Voyages,Occult Moon Games,http://www.drivethrurpg.com/product/141891/Strange-Voyages?affiliate_id=144937
+Mecha vs Kaiju: A Sci-Fi Anime RPG for Fate Core,WrightWerx,https://www.drivethrurpg.com/product/141809/Mecha-vs-Kaiju-Fate-Core?affiliate_id=144937
+Mecha vs Kaiju: Big Book of Kaiju - Land (Fate Core),WrightWerx,http://www.drivethrurpg.com/product/183921/Mecha-vs-Kaiju-Big-Book-of-Kaiju--Land-Fate-Core?affiliate_id=144937
+Mecha vs Kaiju: Big Book of Kaiju - Strange (Fate Core),WrightWerx,http://www.drivethrurpg.com/product/216360/Mecha-vs-Kaiju-Big-Book-of-Kaiju--Strange-Fate-Core?affiliate_id=144937
+Mecha vs Kaiju: Kaijupunk 202X,WrightWerx,https://www.drivethrurpg.com/product/335925/Mecha-vs-Kaiju-Kaijupunk-202X?affiliate_id=144937
+Mecha vs Kaiju: Sensational Sentai Squad GO!,WrightWerx,http://www.rpgnow.com/product/208158/Mecha-vs-Kaiju-Sensational-Sentai-Squad-GO-Fate-Core?affiliate_id=144937
+Mecha vs Kaiju: Steam and Steel - A Fate Steampunk Supplement,WrightWerx,http://drivethrurpg.com/product/183915/Mecha-vs-Kaiju-Steam-and-Steel--A-Fate-Steampunk-Supplement?affiliate_id=144937
+The Book of Hanz,Amazing Rando Design,https://fate-srd.com/store
+Thoughts on Fate: A Collection of Essays on the Fate RPG,Amazing Rando Design,http://www.drivethrurpg.com/product/176051/Thoughts-on-Fate-A-Collection-of-Essays-on-the-Fate-RPG?affiliate_id=144937
+The Secrets of Cats: Animals & Threats,Richard Bellingham,http://www.drivethrurpg.com/product/147773/The-Secrets-of-Cats-Animals--Threats?affiliate_id=144937
+The Secrets of Cats: Feline Magic,Richard Bellingham,https://www.drivethrurpg.com/product/194834/The-Secrets-of-Cats-Feline-Magic?affiliate_id=144937
+"Crestfallen, A Bronze Age Fantasy RPG",White Rose Games,http://www.drivethrurpg.com/product/176630/Crestfallen-RPG?affiliate_id=144937
+Aperita Arcana: Fantasy for Fate Core,Ebon Gryphon Games,http://drivethrurpg.com/product/149698/Aperita-Arcana-fantasy-for-Fate-Core?affiliate_id=144937
+Collectanea Creaturae - Fate Core,Ebon Gryphon Games,http://www.drivethrurpg.com/product/130724/Collectanea-Creaturae--Fate-Core?affiliate_id=144937
+Fate Accompli: Erasable Notecards,Tangent Artists,https://tangentartists.storenvy.com/collections/63855-all-products/products/19754198-fate-accompli-dry-erase-game-cards-warm
+Divine Blood: RPG Supplement,Thrythlind Books and Games,http://www.drivethrurpg.com/product/133609/Divine-Blood-RPG-Supplement?affiliate_id=144937
+Baroque Space Opera,Mark Kowaliszyn,http://www.drivethrurpg.com/product/156171/Baroque-Space-Opera?affiliate_id=144937
+[FAE] Villains Accelerated,Fainting Goat Games,http://drivethrurpg.com/product/134994/FAEVillains-Accelerated?affiliate_id=144937
+Arthur Lives for Fate Core,Fainting Goat Games,http://www.drivethrurpg.com/product/232408/Arthur-Lives-for-Fate-Core?affiliate_id=144937
+Extreme Earth Campaign Setting (FAE version),Fainting Goat Games,http://www.drivethrurpg.com/product/144388/FAE-Extreme-Earth-Campaign-Setting?affiliate_id=144937
+Hunters of Alexandria,D101 Games,http://www.drivethrurpg.com/product/159508/Hunters-of-Alexandria?affiliate_id=144937
+The Hollow West,D101 Games,http://www.drivethrurpg.com/product/222039/The-Hollow-West?affiliate_id=144937
+Strange Stars Fate Rule Book,Hydra Cooperative,http://drivethrurpg.com/product/165972/Strange-Stars-Fate-Rule-Book?affiliate_id=144937
+Divine Instruments of Fate (3EG205),Third Eye Games,http://www.drivethrurpg.com/product/168247/Divine-Instruments-of-Fate-3EG205affiliate_id=144937
+Part-Time Gods of Fate,Third Eye Games,http://drivethrurpg.com/product/152385/PartTime-Gods-of-Fate?affiliate_id=144937
+Leaves of Chiaroscuro: Exploration & Intrigue in the Strange & Wondrous Renaissance,Bennett-Burks Design,http://drivethrurpg.com/product/190834/Leaves-of-Chiaroscuro-Exploration--Intrigue-in-the-Strange--Wondrous-Renaissance?affiliate_id=144937
+Diaspora,VSCA Publishing,http://drivethrurpg.com/product/79933/Diaspora?affiliate_id=144937
+Strays!,Wordsmith Games LLC,http://www.drivethrurpg.com/product/169261/Strays?affiliate_id=144937
+Age of Arthur,Wordplay Games,http://www.drivethrurpg.com/product/111752?affiliate_id=144937
+Time of the Wolves,Wordplay Games,http://www.drivethrurpg.com/product/149507?affiliate_id=144937
+Once Upon a Crime,Wooden Vampire Games,http://www.drivethrurpg.com/product/171284/Once-Upon-a-Crime?affiliate_id=144937
+Out of the Furnace,Smart Party Publishing,http://www.drivethrurpg.com/product/157414/Out-of-the-Furnace?affiliate_id=144937
+Daring Comics Role-Playing Game,Daring Entertainment,http://www.drivethrurpg.com/product/173130/Daring-Comics-RolePlaying-Game?affiliate_id=144937
+Eclipse Phase: Transhumanity's Fate,Posthuman Studios LLC,http://www.drivethrurpg.com/product/176939?affiliate_id=144937
+The Way into Fate,Radar Avenue Press,https://www.drivethrurpg.com/product/179962/The-Way-into-Fate?affiliate_id=144937
+Crashing Beasts & Crumbling Halls,Nothing Ventured Games,https://www.patreon.com/posts/43700788
+It's Element-ary!,Nothing Ventured Games,http://www.drivethrurpg.com/product/179669/Its-Elementary?affiliate_id=144937
+Interface Zero 2.0: Fate Edition,Gun Metal Games,http://drivethrurpg.com/product/186125/Interface-Zero-20-Fate-Edition?affiliate_id=144937
+Evolution Pulse - English Edition,Dreamlord Press,http://drivethrurpg.com/product/185979/Evolution-Pulse--English-Edition?affiliate_id=144937
+Demon Hunters: A Comedy of Terrors,Dead Gentlemen Productions LLC,http://drivethrurpg.com/product/169515/Demon-Hunters-A-Comedy-of-Terrors?affiliate_id=144937
+Ehdrigohr: The Roleplaying Game,Council Of Fools Productions,http://drivethrurpg.com/product/117380/Ehdrigohr-The-Roleplaying-Game?affiliate_id=144937
+Berin Kinsman's Kaiju Patrol,Dancing Lights Press,http://rpg.drivethrustuff.com/product/139656/Berin-Kinsmans-Kaiju-Patrol?affiliate_id=144937
+High Fantasy Magic: A Simple Magic System for Fate Core & Accelerated,Nathan Hare,http://www.drivethrurpg.com/product/199567/High-Fantasy-Magic-A-Simple-Magic-System-for-Fate-Core--Accelerated?affiliate_id=144937
+Breakfast Cult,Liberi Gothica Games,http://www.drivethrurpg.com/product/182520/Breakfast-Cult?affiliate_id=144937
+Game Over - A Breakfast Cult Expansion,Liberi Gothica Games,https://www.drivethrurpg.com/product/237239/Game-Over--A-Breakfast-Cult-Expansion?affiliate_id=144937
+Rockalypse,Four-in-Hand Games,http://www.drivethrurpg.com/product/204869/Rockalypse?affiliate_id=144937
+Wearing the Cape: The Roleplaying Game,Wearing the Cape Productions,https://www.drivethrurpg.com/product/210012/Wearing-the-Cape-The-Roleplaying-Game?affiliate_id=144937
+"Shardland - Muskets, Blades and Words of Power",Judith and Christian Vogt,https://www.drivethrurpg.com/product/209441/Shardland--Muskets-Blades-and-Words-of-Power?affiliate_id=144937
+Ice,Sandy Pug Games,https://www.drivethrurpg.com/product/210633/Ice-Fate?affiliate_id=144937
+Fate Core Rules Presented by Up to 4 Players (Comic summary of the Rules),Up to 4 Players,https://www.uptofourplayers.com/fate-core-rules/
+Thrilling Action Stories! for FATE,Black Campbell Entertainment,http://www.drivethrurpg.com/product/218484/Thrilling-Action-Stories-for-FATE-BUNDLE?affiliate_id=144937
+Carnival of Dreams,MonkeyBlood Design,https://www.drivethrurpg.com/product/228248/Carnival-of-Dreams-Fate?affiliate_id=144937
+Oubliette Second Edition,Voidspiral Entertainment,http://www.drivethrurpg.com/product/204460/Oubliette-Second-Edition?affiliate_id=144937
+Heavy Metal Thunder Mouse,Shoreless Skies Publishing,https://www.drivethrurpg.com/product/220180/Heavy-Metal-Thunder-Mouse?affiliate_id=144937
+Rock 'n' Roll Sock Hop Mouse,Shoreless Skies Publishing,http://drivethrurpg.com/product/245886/Rock-n-Roll-Sock-Hop-Mouse?affiliate_id=144937
+The Kerberos Club (Fate Edition),Arc Dream Publishing,http://www.drivethrurpg.com/product/93899/The-Kerberos-Club-Fate-Edition?affiliate_id=144937
+Warsong Second Edition Core,Higher Grounds,http://www.drivethrurpg.com/product/240868/Warsong-Second-Edition-Core?affiliate_id=144937
+Iron Edda Accelerated,Encoded Designs,https://www.drivethrurpg.com/product/261741/Iron-Edda-Accelerated?affiliate_id=144937
+Titan Hunt,Magnus Hansen,https://www.drivethrurpg.com/product/283664/Titan-Hunt?affiliate_id=144937
+Henchmen,Canterbury Games Studio,https://www.drivethrurpg.com/product/243740/Henchmen?affiliate_id=144937
+London After Nightfall,Leo Winstead,https://www.drivethrurpg.com/product/297490/London-After-Nightfall?affiliate_id=144937
+Mill City Heroes,Leo Winstead,https://www.drivethrurpg.com/product/231480/Mill-City-Heroes?affiliate_id=144937
+The Stuffed Guardians,Benjamin Z. Edelen,https://www.drivethrurpg.com/product/288784/The-Stuffed-Guardians?affiliate_id=144937
+Return to the Stars Core Game,Festive Ninja,https://msabalau.itch.io/return-to-the-stars-rpg
+The Stellar Beacon 2: Sci-Fi Gaming and essays on Fanfiction and Optimism,Festive Ninja,https://msabalau.itch.io/stellar-beacon-2
+The Stellar Beacon: Hopepunk Issue,Festive Ninja,https://msabalau.itch.io/the-stellar-beacon-hopepunk
+The Stellar Beacon: Serendipity,Festive Ninja,https://msabalau.itch.io/the-stellar-beacon-serendipity
+The Stellar Beacon: Trickster Issue,Festive Ninja,https://msabalau.itch.io/trickster
+Smoke and Glass,Phoenix Outlaw Productions,https://www.drivethrurpg.com/product/204213/Smoke-and-Glass?affiliate_id=144937
+Fari.app,Fari.app,https://fari.app/
+RPG Note Cards (For playing Fate Core and similar games online),Jan Tauš,http://fate.masac.cz/
+Fatecharactersheet.com,Darktier Studios LLC,https://fatecharactersheet.com/
+Dreamcraft FATE Bot (Beta),Dreamcraft,https://discord.com/api/oauth2/authorize?client_id=704882221789478930&permissions=272448&scope=bot
+Fate Dice (Android),RPG Automails,https://play.google.com/store/apps/details?id=com.rpgautomails.fatedice&hl=en_US
+Fate Core Folio (iOS),Radical Bomb LLC,https://apps.apple.com/us/app/fate-core-folio/id622434362
+Flatline,Gallant Knight Games,https://www.drivethrurpg.com/product/281193/Flatline?affiliate_id=144937
+True Crime,Pugnacious Games,https://www.drivethrurpg.com/product/315482/True-Crime?affiliate_id=144937
+Bells of the Dark Carol,Silver Lantern Games,https://www.drivethrurpg.com/product/322012?affiliate_id=144937
+Sandfair,Silver Lantern Games,https://www.drivethrurpg.com/product/293952?affiliate_id=144937
+Shadow Over Inowek,Silver Lantern Games,https://www.drivethrurpg.com/product/261398?affiliate_id=144937
+The Explorer's Guide to Escadus,Silver Lantern Games,https://www.drivethrurpg.com/product/304005?affiliate_id=144937
+Writing Fate Content,Silver Lantern Games,https://www.drivethrurpg.com/product/358330/Writing-Fate-Content?affiliate_id=144937
+In Thoth's Wake! - Zine Quest Edition!,Jon Smejkal,https://www.drivethrurpg.com/product/267778?affiliate_id=144937
+Fate Solo,Cabbage Games,https://www.drivethrurpg.com/product/204162/Fate-Solo?affiliate_id=144937
+Space Cats — The Universe's Cutest Roleplaying Game,Pluma Press,https://www.drivethrurpg.com/product/343245/Space-Cats--The-Universes-Cutest-Roleplaying-Game?affiliate_id=144937
+According To Plan,Alex Costello,https://www.drivethrurpg.com/product/302251/According-To-Plan?affiliate_id=144937
+Paranormal Affairs Canada,Tom Hart,https://www.drivethrurpg.com/product/353681/Paranormal-Affairs-Canada?affiliate_id=144937
+Heartbreaker,A.C. Luke,https://ac-luke.itch.io/heartbreaker-trifold
+Seven Demons: A Collection of NPCs for Fate Core,A.C. Luke,https://ac-luke.itch.io/fate-seven-demons
+Seven Hunters: A Collection of NPCs for Fate Core,A.C. Luke,https://ac-luke.itch.io/fate-seven-hunters
+Seven Spirits: A Fate Supplement,A.C. Luke,https://ac-luke.itch.io/fate-seven-spirits
+Aces in Space,Vogt & Vriends,https://www.drivethrurpg.com/product/317497/Aces-In-Space?affiliate_id=144937
+Van Wizards vs The Mageocracy,SicklyGeek,https://jynjynx.itch.io/van-wizards
+El libro de Hanz: la guía para jugar Fate (Book of Hanz fan translation),La esquina del rol,https://laesquinadelrol.com/2021/07/29/librodehanz-epub/
+Alice Black Blood Tribute,Chris Challice,https://www.lulu.com/shop/chris-challice/alice-black-blood-tribute/ebook/product-1q2676jz.html?page=1&pageSize=4
+Traditional Magic for Fate,ambergwitz,https://ambergwitz.itch.io/traditional-magic-for-fate
+Fate Fantastic Creatures,Rolepress,https://www.drivethrurpg.com/product/359590/Fate-Fantastic-Creatures?affiliate_id=144937
+Fate Plus Cyberpunk,Rolepress,https://www.drivethrurpg.com/product/387323/Fate-Plus-Cyberpunk?affiliate_id=144937
+Fate Plus Vikings,Rolepress,https://www.drivethrurpg.com/product/373817/Fate-Plus-Vikings?affiliate_id=144937
+iHunt Abbreviated Reference,Gourmelee Games,https://gourmeleegames.itch.io/ihunt-abbreviated-reference
+Magonomia: the RPG of Renaissance Wizardry,Shewstone Publishing,https://www.drivethrurpg.com/product/366281/Magonomia-the-RPG-of-Renaissance-Wizardry?affiliate_id=144937
+Michtim for Fate,Zev Mir,https://grimogre.itch.io/michtim-fate
+Four-Color FAE,Four-Color FAE,https://www.drivethrurpg.com/product/150994/FourColor-FAE?affiliate_id=144937
+Solarpunk 2050,Thorsten Sick,https://www.drivethrurpg.com/product/443881/Solarpunk-2050?affiliate_id=144937
+Fate of Cthulhu Timeline • The Ascellan Conspiracy,Spotless Dice Games,https://www.drivethrurpg.com/product/433507/Fate-of-Cthulhu-Timeline-o-The-Ascellan-Conspiracy?affiliate_id=144937
+The Chronicles of Future Earth Player's Guide,Typhon Games,https://www.drivethrurpg.com/en/product/471763/the-chronicles-of-future-earth-player-s-guide
+True Crime,Monkey Mind Games,https://www.drivethrurpg.com/en/product/315482?affiliate_id=144937


### PR DESCRIPTION
The first export from Drupal had the following issues:
- URLs were truncated at 80 characters
- The timestamp field existed.

This PR also resolves the changes from #2.

## How to review this PR:

- [ ] Confirm that the Timestamp column has been removed from `fate-product-list.csv`
- [ ] Confirm that the "Link to the product" column has full URLs.
- [ ] Confirm that the link for "Alice Black Blood Tribute" is https://www.lulu.com/shop/chris-challice/alice-black-blood-tribute/ebook/product-1q2676jz.html
