### PR TITLE
Correct the publisher name for Breakfast Cult

### DIFF
--- a/fate-product-list.csv
+++ b/fate-product-list.csv
@@ -236,8 +236,12 @@ Demon Hunters: A Comedy of Terrors,Dead Gentlemen Productions LLC,https://drivet
 Ehdrigohr: The Roleplaying Game,Council Of Fools Productions,https://drivethrurpg.com/product/117380/Ehdrigohr-The-Roleplaying-Game?affiliate_id=144937
 Berin Kinsman's Kaiju Patrol,Dancing Lights Press,http://rpg.drivethrustuff.com/product/139656/Berin-Kinsmans-Kaiju-Patrol?affiliate_id=144937
 High Fantasy Magic: A Simple Magic System for Fate Core & Accelerated,Nathan Hare,https://www.drivethrurpg.com/product/199567/High-Fantasy-Magic-A-Simple-Magic-System-for-Fate-Core--Accelerated?affiliate_id=144937
-Breakfast Cult,Liberi Gothica Games,https://www.drivethrurpg.com/product/182520/Breakfast-Cult?affiliate_id=144937
-Game Over - A Breakfast Cult Expansion,Liberi Gothica Games,https://www.drivethrurpg.com/product/237239/Game-Over--A-Breakfast-Cult-Expansion?affiliate_id=144937
+Breakfast Cult,Weird Age Games,http://www.drivethrurpg.com/product/182520/Breakfast-Cult?affiliate_id=144937
+Breakfast Cult: Game Over,Weird Age Games,https://www.drivethrurpg.com/en/product/237239/breakfast-cult-game-over?affiliate_id=144937
+Breakfast Cult: Sweet Shub and Hella Thotep,Weird Age Games,https://www.drivethrurpg.com/en/product/195267/breakfast-cult-sweet-shub-and-hella-thotep?affiliate_id=144937
+Breakfast Cult: Terrible Friends,Weird Age Games,https://www.drivethrurpg.com/en/product/383186/breakfast-cult-terrible-friends?affiliate_id=144937
+Breakfast Cult: Peer Pressure,Weird Age Games,https://www.drivethrurpg.com/en/product/190174/breakfast-cult-peer-pressure?affiliate_id=144937
+Fractured Skies,Weird Age Games,https://www.drivethrurpg.com/en/product/189765/fractured-skies?affiliate_id=144937
 Rockalypse,Four-in-Hand Games,https://www.drivethrurpg.com/product/204869/Rockalypse?affiliate_id=144937
 Wearing the Cape: The Roleplaying Game,Wearing the Cape Productions,https://www.drivethrurpg.com/product/210012/Wearing-the-Cape-The-Roleplaying-Game?affiliate_id=144937
 "Shardland - Muskets, Blades and Words of Power",Judith and Christian Vogt,https://www.drivethrurpg.com/product/209441/Shardland--Muskets-Blades-and-Words-of-Power?affiliate_id=144937

--- a/fate-product-list.csv
+++ b/fate-product-list.csv
@@ -210,12 +210,8 @@ Timestamp,Product title,Publisher Name,Link to the product
 6/21/2024,El libro de Hanz: la guía para jugar Fate (Book of Hanz fan translation),La esquina del rol,https://laesquinadelrol.com/2021/07/29/librodehanz-epub/
 6/21/2024,London After Nightfall,Leo Winstead,https://www.drivethrurpg.com/product/297490/London-After-Nightfall?affiliate_id…
 6/21/2024,Mill City Heroes,Leo Winstead,https://www.drivethrurpg.com/product/231480/Mill-City-Heroes?affiliate_id=144937
-6/21/2024,Breakfast Cult,Weird Age Games,http://www.drivethrurpg.com/product/182520/Breakfast-Cult?affiliate_id=144937
-6/21/2024,Game Over - A Breakfast Cult Expansion,Weird Age Games,https://www.drivethrurpg.com/product/237239/Game-Over--A-Breakfast-Cult-Expansi…
-6/21/2024,Breakfast Cult: Sweet Shub and Hella Thotep,Weird Age Games,https://www.drivethrurpg.com/en/product/195267/breakfast-cult-sweet-shub-and-hella-thotep?affiliate_id=144937
-6/21/2024,Breakfast Cult: Terrible Friends,Weird Age Games,https://www.drivethrurpg.com/en/product/383186/breakfast-cult-terrible-friends?affiliate_id=144937
-6/21/2024,Breakfast Cult: Peer Pressure,Weird Age Games,https://www.drivethrurpg.com/en/product/190174/breakfast-cult-peer-pressure?affiliate_id=144937
-6/21/2024,Fractured Skies,Weird Age Games,https://www.drivethrurpg.com/en/product/189765/fractured-skies?affiliate_id=144937
+6/21/2024,Breakfast Cult,Liberi Gothica Games,http://www.drivethrurpg.com/product/182520/Breakfast-Cult?affiliate_id=144937
+6/21/2024,Game Over - A Breakfast Cult Expansion,Liberi Gothica Games,https://www.drivethrurpg.com/product/237239/Game-Over--A-Breakfast-Cult-Expansi…
 6/21/2024,#iHunt: The RPG,Machine Age Productions,https://www.drivethrurpg.com/product/298255/iHunt-The-RPG?affiliate_id=144937
 6/21/2024,Apotheosis Drive X - Fate-Powered Mecha RPG - HD Mix,Machine Age Productions,https://www.drivethrurpg.com/product/147795/Apotheosis-Drive-X--FatePowered-Mec…
 6/21/2024,Titan Hunt,Magnus Hansen,https://www.drivethrurpg.com/product/283664/Titan-Hunt?affiliate_id=144937

--- a/fate-product-list.csv
+++ b/fate-product-list.csv
@@ -210,8 +210,12 @@ Timestamp,Product title,Publisher Name,Link to the product
 6/21/2024,El libro de Hanz: la guía para jugar Fate (Book of Hanz fan translation),La esquina del rol,https://laesquinadelrol.com/2021/07/29/librodehanz-epub/
 6/21/2024,London After Nightfall,Leo Winstead,https://www.drivethrurpg.com/product/297490/London-After-Nightfall?affiliate_id…
 6/21/2024,Mill City Heroes,Leo Winstead,https://www.drivethrurpg.com/product/231480/Mill-City-Heroes?affiliate_id=144937
-6/21/2024,Breakfast Cult,Liberi Gothica Games,http://www.drivethrurpg.com/product/182520/Breakfast-Cult?affiliate_id=144937
-6/21/2024,Game Over - A Breakfast Cult Expansion,Liberi Gothica Games,https://www.drivethrurpg.com/product/237239/Game-Over--A-Breakfast-Cult-Expansi…
+6/21/2024,Breakfast Cult,Weird Age Games,http://www.drivethrurpg.com/product/182520/Breakfast-Cult?affiliate_id=144937
+6/21/2024,Game Over - A Breakfast Cult Expansion,Weird Age Games,https://www.drivethrurpg.com/product/237239/Game-Over--A-Breakfast-Cult-Expansi…
+6/21/2024,Breakfast Cult: Sweet Shub and Hella Thotep,Weird Age Games,https://www.drivethrurpg.com/en/product/195267/breakfast-cult-sweet-shub-and-hella-thotep?affiliate_id=144937
+6/21/2024,Breakfast Cult: Terrible Friends,Weird Age Games,https://www.drivethrurpg.com/en/product/383186/breakfast-cult-terrible-friends?affiliate_id=144937
+6/21/2024,Breakfast Cult: Peer Pressure,Weird Age Games,https://www.drivethrurpg.com/en/product/190174/breakfast-cult-peer-pressure?affiliate_id=144937
+6/21/2024,Fractured Skies,Weird Age Games,https://www.drivethrurpg.com/en/product/189765/fractured-skies?affiliate_id=144937
 6/21/2024,#iHunt: The RPG,Machine Age Productions,https://www.drivethrurpg.com/product/298255/iHunt-The-RPG?affiliate_id=144937
 6/21/2024,Apotheosis Drive X - Fate-Powered Mecha RPG - HD Mix,Machine Age Productions,https://www.drivethrurpg.com/product/147795/Apotheosis-Drive-X--FatePowered-Mec…
 6/21/2024,Titan Hunt,Magnus Hansen,https://www.drivethrurpg.com/product/283664/Titan-Hunt?affiliate_id=144937


### PR DESCRIPTION
* I assume the publisher changes somewhere between the publishing of Breakfast Cult and the non-Fate Hard Wired Island.
    * Paul Matijevic (the author of Breakfast Cult) is def involved in Weird Age Games.
      Their [itch.io page] uses his nickname as part of the URL _and_ links to his Twitter profile as the one for Weird Age Games.
* Also adding a non-Breakfast Cult setting for Fate to the list.


[itch.io page]: https://ettin.itch.io/