### PR TITLE
upgrade workflow to node 24

### DIFF
--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -13,15 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup nodejs
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: "20.x"
+          node-version: "24.x"
 
       - run: npm ci
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "csv-parse": "^5.5.6"
       },
       "engines": {
-        "node": "20.x"
+        "node": "24.x"
       }
     },
     "node_modules/csv-parse": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "git+https://github.com/fate-srd/fate-product-list.git"
   },
   "engines": {
-    "node": "20.x"
+    "node": "24.x"
   },
   "author": "amazingrando",
   "license": "ISC",


### PR DESCRIPTION
`.github/workflows/version-bump.yaml` needs this project to be upgraded from Node 20 to Node 24 to continue to run successfully.